### PR TITLE
adding ingredient, ingredient_category models and specs

### DIFF
--- a/nourish_api/app/models/ingredient.rb
+++ b/nourish_api/app/models/ingredient.rb
@@ -1,6 +1,9 @@
 class Ingredient < ApplicationRecord
+  
+  # ingredient has 1:m relationship with ingredient_category
   belongs_to :ingredient_category
 
+  # must have a name
   validates_presence_of :name
 
 end

--- a/nourish_api/app/models/ingredient.rb
+++ b/nourish_api/app/models/ingredient.rb
@@ -1,0 +1,6 @@
+class Ingredient < ApplicationRecord
+  belongs_to :ingredient_category
+
+  validates_presence_of :name
+
+end

--- a/nourish_api/app/models/ingredient_category.rb
+++ b/nourish_api/app/models/ingredient_category.rb
@@ -1,0 +1,9 @@
+class IngredientCategory < ApplicationRecord
+    # name must exist
+    validates_presence_of :name
+
+    # has-many ingredients (1 category : n ingredients), 
+    # when category is deleted, dependent fields are nullified
+    has_many :ingredients, dependent: :nullify
+
+end

--- a/nourish_api/db/migrate/20180419192153_create_ingredient_categories.rb
+++ b/nourish_api/db/migrate/20180419192153_create_ingredient_categories.rb
@@ -1,0 +1,9 @@
+class CreateIngredientCategories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :ingredient_categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/nourish_api/db/migrate/20180419193110_create_ingredients.rb
+++ b/nourish_api/db/migrate/20180419193110_create_ingredients.rb
@@ -1,0 +1,10 @@
+class CreateIngredients < ActiveRecord::Migration[5.1]
+  def change
+    create_table :ingredients do |t|
+      t.string :name
+      t.references :ingredient_category, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/nourish_api/db/schema.rb
+++ b/nourish_api/db/schema.rb
@@ -10,6 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20180419193110) do
 
+  create_table "ingredient_categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "ingredients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "name"
+    t.bigint "ingredient_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ingredient_category_id"], name: "index_ingredients_on_ingredient_category_id"
+  end
+
+  add_foreign_key "ingredients", "ingredient_categories"
 end

--- a/nourish_api/spec/models/ingredient_category_spec.rb
+++ b/nourish_api/spec/models/ingredient_category_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe IngredientCategory, type: :model do
+
+  # destroying a category should nullify the 'category' FK in ingredients
+  it { should have_many(:ingredients).dependent(:nullify) }
+
+  # name must exist
+  it { should validate_presence_of(:name) }
+
+end

--- a/nourish_api/spec/models/ingredient_spec.rb
+++ b/nourish_api/spec/models/ingredient_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Ingredient, type: :model do
   it { should validate_presence_of(:name) }
 
   # must belong to one category
- # it { should belong_to(:ingredient_category) }
-
-  #  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to(:ingredient_category) }
 
 end

--- a/nourish_api/spec/models/ingredient_spec.rb
+++ b/nourish_api/spec/models/ingredient_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Ingredient, type: :model do
+
+  # must have a name
+  it { should validate_presence_of(:name) }
+
+  # must belong to one category
+ # it { should belong_to(:ingredient_category) }
+
+  #  pending "add some examples to (or delete) #{__FILE__}"
+
+end


### PR DESCRIPTION
Added Ingredient and Ingredient_Category models, along with rspec tests.

Note that as currently specified, when an Ingredient_Category is deleted, any dependent foreign key references in Ingredient are set to NULL. So, it is possible for ingredients to exist sans ingredient_category. 