### PR TITLE
Ingredient and Ingredient_Category models, specs, factories, controllers

### DIFF
--- a/nourish_api/app/controllers/application_controller.rb
+++ b/nourish_api/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+    include ExceptionHandler
 end

--- a/nourish_api/app/controllers/application_controller.rb
+++ b/nourish_api/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::API
-    include ExceptionHandler
+  include ExceptionHandler
 end

--- a/nourish_api/app/controllers/concerns/exception_handler.rb
+++ b/nourish_api/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,28 @@
+# exception handler for json responses, when item not in database
+# adapted from: https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one
+
+module ExceptionHandler
+
+    # extending Concern gives us 'included' syntax
+    extend ActiveSupport::Concern
+
+    included do 
+
+        # handle 'record not found' errors
+        # return error message+ '404'
+        rescue_from ActiveRecord::RecordNotFound do |e|
+            # return json response containing error message, status of :not_found
+            render json: {message: e.message}, status: :not_found
+        end
+
+        # handle 'invalid record' errors
+        # return error message + '422'
+        rescue_from ActiveRecord::RecordInvalid do |e|
+            render json: {message: e.message}, status: :unprocessable_entity
+        end
+
+    end
+
+end
+
+

--- a/nourish_api/app/controllers/concerns/exception_handler.rb
+++ b/nourish_api/app/controllers/concerns/exception_handler.rb
@@ -3,25 +3,25 @@
 
 module ExceptionHandler
 
-    # extending Concern gives us 'included' syntax
-    extend ActiveSupport::Concern
+  # extending Concern gives us 'included' syntax
+  extend ActiveSupport::Concern
 
-    included do 
+  included do 
 
-        # handle 'record not found' errors
-        # return error message+ '404'
-        rescue_from ActiveRecord::RecordNotFound do |e|
-            # return json response containing error message, status of :not_found
-            render json: {message: e.message}, status: :not_found
-        end
-
-        # handle 'invalid record' errors
-        # return error message + '422'
-        rescue_from ActiveRecord::RecordInvalid do |e|
-            render json: {message: e.message}, status: :unprocessable_entity
-        end
-
+    # handle 'record not found' errors
+    # return error message+ '404'
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      # return json response containing error message, status of :not_found
+      render json: {message: e.message}, status: :not_found
     end
+
+    # handle 'invalid record' errors
+    # return error message + '422'
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      render json: {message: e.message}, status: :unprocessable_entity
+    end
+
+  end
 
 end
 

--- a/nourish_api/app/controllers/ingredient_categories_controller.rb
+++ b/nourish_api/app/controllers/ingredient_categories_controller.rb
@@ -1,0 +1,50 @@
+# IngredientCategories controller
+# /app/controllers/ingredient_categories_controller.rb
+
+class IngredientCategoriesController < ApplicationController
+
+    before_action :set_ingredient_category, only: [:show, :update, :destroy]
+
+    # GET /ingredient_categories
+    def index
+        @ingredientcategories = IngredientCategory.all
+        render json: @ingredientcategories, status: :ok
+    end
+
+    # POST /ingredient_categories
+    def create
+        @ingredientcategory = IngredientCategory.create!(ingredient_category_params)
+        render json: @ingredientcategory, status: :created
+    end
+
+    # GET /ingredient_categories/:id
+    def show
+        render json: @ingredientcategory, status: :ok
+    end
+
+    # UPDATE /ingredient_categories/:id
+    def update 
+        @ingredientcategory.update(ingredient_category_params)
+        head :no_content
+    end
+
+    # DELETE /ingredient_categories/:id
+    def destroy 
+        @ingredientcategory.destroy
+        head :no_content
+    end 
+    
+
+    private
+    
+        # set @ingredientcategory for GET, UPDATE, DEPETE
+        def set_ingredient_category
+            @ingredientcategory = IngredientCategory.find(params[:id])
+        end
+
+        # whitelist fields
+        def ingredient_category_params
+            params.permit(:name)
+        end
+
+end

--- a/nourish_api/app/controllers/ingredient_categories_controller.rb
+++ b/nourish_api/app/controllers/ingredient_categories_controller.rb
@@ -34,7 +34,6 @@ class IngredientCategoriesController < ApplicationController
         head :no_content
     end 
     
-
     private
     
         # set @ingredientcategory for GET, UPDATE, DEPETE

--- a/nourish_api/app/controllers/ingredient_categories_controller.rb
+++ b/nourish_api/app/controllers/ingredient_categories_controller.rb
@@ -3,47 +3,47 @@
 
 class IngredientCategoriesController < ApplicationController
 
-    before_action :set_ingredient_category, only: [:show, :update, :destroy]
+  before_action :set_ingredient_category, only: [:show, :update, :destroy]
 
-    # GET /ingredient_categories
-    def index
-        @ingredientcategories = IngredientCategory.all
-        render json: @ingredientcategories, status: :ok
+  # GET /ingredient_categories
+  def index
+    @ingredientcategories = IngredientCategory.all
+    render json: @ingredientcategories, status: :ok
+  end
+
+  # POST /ingredient_categories
+  def create
+    @ingredientcategory = IngredientCategory.create!(ingredient_category_params)
+    render json: @ingredientcategory, status: :created
+  end
+
+  # GET /ingredient_categories/:id
+  def show
+    render json: @ingredientcategory, status: :ok
+  end
+
+  # UPDATE /ingredient_categories/:id
+  def update 
+    @ingredientcategory.update(ingredient_category_params)
+    head :no_content
+  end
+
+  # DELETE /ingredient_categories/:id
+  def destroy 
+    @ingredientcategory.destroy
+    head :no_content
+  end 
+  
+  private
+  
+    # set @ingredientcategory for GET, UPDATE, DEPETE
+    def set_ingredient_category
+      @ingredientcategory = IngredientCategory.find(params[:id])
     end
 
-    # POST /ingredient_categories
-    def create
-        @ingredientcategory = IngredientCategory.create!(ingredient_category_params)
-        render json: @ingredientcategory, status: :created
+    # whitelist fields
+    def ingredient_category_params
+      params.permit(:name)
     end
-
-    # GET /ingredient_categories/:id
-    def show
-        render json: @ingredientcategory, status: :ok
-    end
-
-    # UPDATE /ingredient_categories/:id
-    def update 
-        @ingredientcategory.update(ingredient_category_params)
-        head :no_content
-    end
-
-    # DELETE /ingredient_categories/:id
-    def destroy 
-        @ingredientcategory.destroy
-        head :no_content
-    end 
-    
-    private
-    
-        # set @ingredientcategory for GET, UPDATE, DEPETE
-        def set_ingredient_category
-            @ingredientcategory = IngredientCategory.find(params[:id])
-        end
-
-        # whitelist fields
-        def ingredient_category_params
-            params.permit(:name)
-        end
 
 end

--- a/nourish_api/app/controllers/ingredients_controller.rb
+++ b/nourish_api/app/controllers/ingredients_controller.rb
@@ -1,0 +1,54 @@
+# Ingredients controller
+# /app/controllers/ingredients_controller.rb
+
+class IngredientsController < ApplicationController
+
+    before_action :set_ingredient_category, only: [:index, :create]
+    before_action :set_ingredient, only: [:show, :update, :destroy]
+
+# GET /ingredient_categories/:ingredient_category_id/ingredients/
+def index
+    render json: @ingredientcategory.ingredients, status: :ok
+end
+
+# GET /ingredients/:id
+def show 
+    render json: @ingredient, status: :ok
+end
+
+# POST /ingredient_categories/:ingredient_category_id/ingredients/
+def create 
+    @ingredientcategory.ingredients.create!(ingredient_params)
+    render json: @ingredientcategory, status: :created
+end
+
+# PUT /ingredients/:id
+def update
+    @ingredient.update(ingredient_params)
+    head :no_content
+end
+
+# DELETE /ingredients/:id
+def destroy
+    @ingredient.destroy
+    head :no_content
+end
+
+private
+
+    # define acceptable params
+    def ingredient_params
+        params.permit(:name, :ingredient_category_id)
+    end
+
+    # find a single ingredient_category
+    def set_ingredient_category
+        @ingredientcategory = IngredientCategory.find(params[:ingredient_category_id])
+    end
+
+    # find a single ingredient by id
+    def set_ingredient
+        @ingredient = Ingredient.find(params[:id])
+    end
+
+end

--- a/nourish_api/app/controllers/ingredients_controller.rb
+++ b/nourish_api/app/controllers/ingredients_controller.rb
@@ -3,52 +3,52 @@
 
 class IngredientsController < ApplicationController
 
-    before_action :set_ingredient_category, only: [:index, :create]
-    before_action :set_ingredient, only: [:show, :update, :destroy]
+  before_action :set_ingredient_category, only: [:index, :create]
+  before_action :set_ingredient, only: [:show, :update, :destroy]
 
-    # GET /ingredient_categories/:ingredient_category_id/ingredients/
-    def index
-        render json: @ingredientcategory.ingredients, status: :ok
+  # GET /ingredient_categories/:ingredient_category_id/ingredients/
+  def index
+    render json: @ingredientcategory.ingredients, status: :ok
+  end
+
+  # GET /ingredients/:id
+  def show 
+    render json: @ingredient, status: :ok
+  end
+
+  # POST /ingredient_categories/:ingredient_category_id/ingredients/
+  def create 
+    @ingredientcategory.ingredients.create!(ingredient_params)
+    render json: @ingredientcategory, status: :created
+  end
+
+  # PUT /ingredients/:id
+  def update
+    @ingredient.update(ingredient_params)
+    head :no_content
+  end
+
+  # DELETE /ingredients/:id
+  def destroy
+    @ingredient.destroy
+    head :no_content
+  end
+
+  private
+
+    # define acceptable params
+    def ingredient_params
+      params.permit(:name, :ingredient_category_id)
     end
 
-    # GET /ingredients/:id
-    def show 
-        render json: @ingredient, status: :ok
+    # find a single ingredient_category
+    def set_ingredient_category
+      @ingredientcategory = IngredientCategory.find(params[:ingredient_category_id])
     end
 
-    # POST /ingredient_categories/:ingredient_category_id/ingredients/
-    def create 
-        @ingredientcategory.ingredients.create!(ingredient_params)
-        render json: @ingredientcategory, status: :created
+    # find a single ingredient by id
+    def set_ingredient
+      @ingredient = Ingredient.find(params[:id])
     end
-
-    # PUT /ingredients/:id
-    def update
-        @ingredient.update(ingredient_params)
-        head :no_content
-    end
-
-    # DELETE /ingredients/:id
-    def destroy
-        @ingredient.destroy
-        head :no_content
-    end
-
-    private
-
-        # define acceptable params
-        def ingredient_params
-            params.permit(:name, :ingredient_category_id)
-        end
-
-        # find a single ingredient_category
-        def set_ingredient_category
-            @ingredientcategory = IngredientCategory.find(params[:ingredient_category_id])
-        end
-
-        # find a single ingredient by id
-        def set_ingredient
-            @ingredient = Ingredient.find(params[:id])
-        end
 
 end

--- a/nourish_api/app/controllers/ingredients_controller.rb
+++ b/nourish_api/app/controllers/ingredients_controller.rb
@@ -6,49 +6,49 @@ class IngredientsController < ApplicationController
     before_action :set_ingredient_category, only: [:index, :create]
     before_action :set_ingredient, only: [:show, :update, :destroy]
 
-# GET /ingredient_categories/:ingredient_category_id/ingredients/
-def index
-    render json: @ingredientcategory.ingredients, status: :ok
-end
-
-# GET /ingredients/:id
-def show 
-    render json: @ingredient, status: :ok
-end
-
-# POST /ingredient_categories/:ingredient_category_id/ingredients/
-def create 
-    @ingredientcategory.ingredients.create!(ingredient_params)
-    render json: @ingredientcategory, status: :created
-end
-
-# PUT /ingredients/:id
-def update
-    @ingredient.update(ingredient_params)
-    head :no_content
-end
-
-# DELETE /ingredients/:id
-def destroy
-    @ingredient.destroy
-    head :no_content
-end
-
-private
-
-    # define acceptable params
-    def ingredient_params
-        params.permit(:name, :ingredient_category_id)
+    # GET /ingredient_categories/:ingredient_category_id/ingredients/
+    def index
+        render json: @ingredientcategory.ingredients, status: :ok
     end
 
-    # find a single ingredient_category
-    def set_ingredient_category
-        @ingredientcategory = IngredientCategory.find(params[:ingredient_category_id])
+    # GET /ingredients/:id
+    def show 
+        render json: @ingredient, status: :ok
     end
 
-    # find a single ingredient by id
-    def set_ingredient
-        @ingredient = Ingredient.find(params[:id])
+    # POST /ingredient_categories/:ingredient_category_id/ingredients/
+    def create 
+        @ingredientcategory.ingredients.create!(ingredient_params)
+        render json: @ingredientcategory, status: :created
     end
+
+    # PUT /ingredients/:id
+    def update
+        @ingredient.update(ingredient_params)
+        head :no_content
+    end
+
+    # DELETE /ingredients/:id
+    def destroy
+        @ingredient.destroy
+        head :no_content
+    end
+
+    private
+
+        # define acceptable params
+        def ingredient_params
+            params.permit(:name, :ingredient_category_id)
+        end
+
+        # find a single ingredient_category
+        def set_ingredient_category
+            @ingredientcategory = IngredientCategory.find(params[:ingredient_category_id])
+        end
+
+        # find a single ingredient by id
+        def set_ingredient
+            @ingredient = Ingredient.find(params[:id])
+        end
 
 end

--- a/nourish_api/app/models/ingredient_category.rb
+++ b/nourish_api/app/models/ingredient_category.rb
@@ -1,9 +1,9 @@
 class IngredientCategory < ApplicationRecord
-    # name must exist
-    validates_presence_of :name
+  # name must exist
+  validates_presence_of :name
 
-    # has-many ingredients (1 category : n ingredients), 
-    # when category is deleted, dependent fields are nullified
-    has_many :ingredients, dependent: :nullify
+  # has-many ingredients (1 category : n ingredients), 
+  # when category is deleted, dependent fields are nullified
+  has_many :ingredients, dependent: :nullify
 
 end

--- a/nourish_api/config/routes.rb
+++ b/nourish_api/config/routes.rb
@@ -4,5 +4,14 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   constraints subdomain: 'api' do
   end
+
+  # set up ingredient_categories / ingredients routes
+  # (1 category : m ingredients)
+  resources :ingredient_categories do
+    resources :ingredients, only: [:index, :create]
+  end
+
+  resources :ingredients, only: [:show, :update, :destroy]
+
 end
 

--- a/nourish_api/spec/controllers/ingredient_categories_controller_spec.rb
+++ b/nourish_api/spec/controllers/ingredient_categories_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IngredientCategoriesController, type: :controller do
+
+end

--- a/nourish_api/spec/controllers/ingredients_controller_spec.rb
+++ b/nourish_api/spec/controllers/ingredients_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IngredientsController, type: :controller do
+
+end

--- a/nourish_api/spec/factories/ingredient_categories.rb
+++ b/nourish_api/spec/factories/ingredient_categories.rb
@@ -1,0 +1,8 @@
+# ingredient_category factory
+# /spec/factories/ingredient_categories.rb
+
+FactoryBot.define do
+    factory :ingredient_category do
+        name { Faker::Lorem.word }
+    end
+end

--- a/nourish_api/spec/factories/ingredient_categories.rb
+++ b/nourish_api/spec/factories/ingredient_categories.rb
@@ -2,7 +2,7 @@
 # /spec/factories/ingredient_categories.rb
 
 FactoryBot.define do
-    factory :ingredient_category do
-        name { Faker::Lorem.word }
-    end
+  factory :ingredient_category do
+    name { Faker::Lorem.word }
+  end
 end

--- a/nourish_api/spec/factories/ingredients.rb
+++ b/nourish_api/spec/factories/ingredients.rb
@@ -1,0 +1,9 @@
+# ingredient factory
+# spec/factories/ingredients.rb
+
+FactoryBot.define do
+    factory :ingredient do
+        name { Faker::Lorem.word }
+        ingredient_category_id nil
+    end
+end

--- a/nourish_api/spec/factories/ingredients.rb
+++ b/nourish_api/spec/factories/ingredients.rb
@@ -2,8 +2,8 @@
 # spec/factories/ingredients.rb
 
 FactoryBot.define do
-    factory :ingredient do
-        name { Faker::Lorem.word }
-        ingredient_category_id nil
-    end
+  factory :ingredient do
+    name { Faker::Lorem.word }
+    ingredient_category_id nil
+  end
 end

--- a/nourish_api/spec/models/ingredient_category_spec.rb
+++ b/nourish_api/spec/models/ingredient_category_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe IngredientCategory, type: :model do
 
   # destroying a category should nullify the 'category' FK in ingredients
-  it { should have_many(:ingredients).dependent(:nullify) }
+  it { is_expected.to have_many(:ingredients).dependent(:nullify) }
 
   # name must exist
-  it { should validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:name) }
 
 end

--- a/nourish_api/spec/models/ingredient_category_spec.rb
+++ b/nourish_api/spec/models/ingredient_category_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe IngredientCategory, type: :model do
   it { is_expected.to have_many(:ingredients).dependent(:nullify) }
 
   # name must exist
-  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of :name }
 
 end

--- a/nourish_api/spec/models/ingredient_category_spec.rb
+++ b/nourish_api/spec/models/ingredient_category_spec.rb
@@ -1,3 +1,6 @@
+# IngredientCategory model spec
+# /spec/models/ingredient_category_spec.rb
+
 require 'rails_helper'
 
 RSpec.describe IngredientCategory, type: :model do

--- a/nourish_api/spec/models/ingredient_spec.rb
+++ b/nourish_api/spec/models/ingredient_spec.rb
@@ -1,3 +1,6 @@
+# Ingredient model spec
+# /spec/models/ingredient_spec.rb
+
 require 'rails_helper'
 
 RSpec.describe Ingredient, type: :model do

--- a/nourish_api/spec/models/ingredient_spec.rb
+++ b/nourish_api/spec/models/ingredient_spec.rb
@@ -6,9 +6,9 @@ require 'rails_helper'
 RSpec.describe Ingredient, type: :model do
 
   # must have a name
-  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of :name }
 
   # must belong to one category
-  it { is_expected.to belong_to(:ingredient_category) }
+  it { is_expected.to belong_to :ingredient_category }
 
 end

--- a/nourish_api/spec/models/ingredient_spec.rb
+++ b/nourish_api/spec/models/ingredient_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Ingredient, type: :model do
 
   # must have a name
-  it { should validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:name) }
 
   # must belong to one category
-  it { should belong_to(:ingredient_category) }
+  it { is_expected.to belong_to(:ingredient_category) }
 
 end

--- a/nourish_api/spec/rails_helper.rb
+++ b/nourish_api/spec/rails_helper.rb
@@ -66,6 +66,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # include request spec helper as shared module for all request specs
+  config.include RequestSpecHelper, type: :request
+
   # add `FactoryBot` methods
   config.include FactoryBot::Syntax::Methods
 

--- a/nourish_api/spec/requests/ingredient_categories_spec.rb
+++ b/nourish_api/spec/requests/ingredient_categories_spec.rb
@@ -1,0 +1,113 @@
+# ingredient_category request spec
+# /spec/request/ingredient_categories_spec.rb
+# test methods adapted from: https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one
+
+require 'rails_helper'
+
+RSpec.describe 'IngredientCategory API', type: :request do
+    let!(:ingredient_categories) { create_list(:ingredient_category, 10) }
+    let(:ingredient_category_id) { ingredient_categories.first.id }
+
+    # spec for GET/ingredient_categories
+    describe 'GET /ingredient_categories' do
+        before { get '/ingredient_categories' }
+
+        it 'returns ingredient_categories' do
+
+            expect(json).not_to be_empty
+            expect(json.size).to eq 10
+
+        end
+
+        it 'returns status 200' do  
+            expect(response).to have_http_status 200
+        end
+    end 
+
+    # spec for GET /ingredient_categories/:id
+    describe 'GET /ingredient_categories/:id' do
+        before { get "/ingredient_categories/#{ingredient_category_id}" }
+
+        # expect a request for category id of :ingredient_category_id
+        context 'when the record exists' do
+            it 'returns the ingredient' do
+                expect(json).not_to be_empty
+                expect(json['id']).to eq ingredient_category_id
+            end
+
+            it 'returns status code 200' do
+                expect(response).to have_http_status 200
+            end
+        end
+    
+        context 'when the record does not exist' do
+            let(:ingredient_category_id) { 99 }
+
+            it 'returns status code 404' do
+                expect(response).to have_http_status 404
+            end
+
+            it 'returns not found message' do
+                expect(response.body).to match /Couldn't find IngredientCategory/
+            end
+        end    
+    end
+
+    # spec for POST /ingredient_category
+    describe 'POST /ingredient_categories' do
+        let(:valid_attributes) { {name: 'Dairy'} }
+
+        context 'when request is valid' do
+            before { post '/ingredient_categories', params: valid_attributes}
+
+            it 'creates an ingredient category' do
+                expect( json['name'] ).to eq 'Dairy'
+            end
+
+            it 'returns status code 201' do
+                expect(response).to have_http_status 201
+            end
+        end
+
+        context 'when request is invalid' do
+            before { post '/ingredient_categories', params: { } }
+
+            it 'returns status code 422' do
+                expect(response).to have_http_status 422
+            end
+
+            it 'returns validation failure message' do
+                expect(response.body).to match /Validation failed: Name can't be blank/
+            end
+        end
+    end
+
+
+    # spec for PUT /ingredient_category/:id
+    describe 'PUT /ingredient_categories/:id' do
+        let(:valid_attributes) { {name: 'Dairy'} } 
+
+        context 'when record exists' do
+            before { put "/ingredient_categories/#{ingredient_category_id}", params: valid_attributes}
+
+            it 'updates the record' do
+                expect(response.body).to be_empty
+            end
+
+            it 'returns status code 204' do
+                expect(response).to have_http_status 204
+            end
+        end
+    end
+
+    # spec for DELETE /ingredient_category/:id
+    describe 'DELETE /ingredient_categories/:id' do
+
+        before { delete "/ingredient_categories/#{ingredient_category_id}" }
+
+        it 'returns status code 204' do
+            expect(response).to have_http_status 204 
+        end
+    end
+end
+    

--- a/nourish_api/spec/requests/ingredient_categories_spec.rb
+++ b/nourish_api/spec/requests/ingredient_categories_spec.rb
@@ -10,22 +10,23 @@ RSpec.describe 'IngredientCategory API', type: :request do
 
     # spec for GET/ingredient_categories
     describe 'GET /ingredient_categories' do
+
         before { get '/ingredient_categories' }
 
         it 'returns ingredient_categories' do
-
             expect(json).not_to be_empty
             expect(json.size).to eq 10
-
         end
 
         it 'returns status 200' do  
             expect(response).to have_http_status 200
         end
+ 
     end 
 
     # spec for GET /ingredient_categories/:id
     describe 'GET /ingredient_categories/:id' do
+ 
         before { get "/ingredient_categories/#{ingredient_category_id}" }
 
         # expect a request for category id of :ingredient_category_id
@@ -51,10 +52,12 @@ RSpec.describe 'IngredientCategory API', type: :request do
                 expect(response.body).to match /Couldn't find IngredientCategory/
             end
         end    
+ 
     end
 
     # spec for POST /ingredient_category
     describe 'POST /ingredient_categories' do
+  
         let(:valid_attributes) { {name: 'Dairy'} }
 
         context 'when request is valid' do
@@ -80,11 +83,13 @@ RSpec.describe 'IngredientCategory API', type: :request do
                 expect(response.body).to match /Validation failed: Name can't be blank/
             end
         end
+ 
     end
 
 
     # spec for PUT /ingredient_category/:id
     describe 'PUT /ingredient_categories/:id' do
+
         let(:valid_attributes) { {name: 'Dairy'} } 
 
         context 'when record exists' do
@@ -98,6 +103,7 @@ RSpec.describe 'IngredientCategory API', type: :request do
                 expect(response).to have_http_status 204
             end
         end
+
     end
 
     # spec for DELETE /ingredient_category/:id
@@ -108,6 +114,8 @@ RSpec.describe 'IngredientCategory API', type: :request do
         it 'returns status code 204' do
             expect(response).to have_http_status 204 
         end
+  
     end
+
 end
     

--- a/nourish_api/spec/requests/ingredient_categories_spec.rb
+++ b/nourish_api/spec/requests/ingredient_categories_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'IngredientCategory API', type: :request do
  
   end
 
-  # spec for POST /ingredient_category
+  # spec for POST /ingredient_categories
   describe 'POST /ingredient_categories' do
   
     let(:valid_attributes) { {name: 'Dairy'} }
@@ -87,7 +87,7 @@ RSpec.describe 'IngredientCategory API', type: :request do
   end
 
 
-  # spec for PUT /ingredient_category/:id
+  # spec for PUT /ingredient_categories/:id
   describe 'PUT /ingredient_categories/:id' do
 
     let(:valid_attributes) { {name: 'Dairy'} } 
@@ -106,7 +106,7 @@ RSpec.describe 'IngredientCategory API', type: :request do
 
   end
 
-  # spec for DELETE /ingredient_category/:id
+  # spec for DELETE /ingredient_categories/:id
   describe 'DELETE /ingredient_categories/:id' do
 
     before { delete "/ingredient_categories/#{ingredient_category_id}" }

--- a/nourish_api/spec/requests/ingredient_categories_spec.rb
+++ b/nourish_api/spec/requests/ingredient_categories_spec.rb
@@ -5,117 +5,117 @@
 require 'rails_helper'
 
 RSpec.describe 'IngredientCategory API', type: :request do
-    let!(:ingredient_categories) { create_list(:ingredient_category, 10) }
-    let(:ingredient_category_id) { ingredient_categories.first.id }
+  let!(:ingredient_categories) { create_list(:ingredient_category, 10) }
+  let(:ingredient_category_id) { ingredient_categories.first.id }
 
-    # spec for GET/ingredient_categories
-    describe 'GET /ingredient_categories' do
+  # spec for GET/ingredient_categories
+  describe 'GET /ingredient_categories' do
 
-        before { get '/ingredient_categories' }
+    before { get '/ingredient_categories' }
 
-        it 'returns ingredient_categories' do
-            expect(json).not_to be_empty
-            expect(json.size).to eq 10
-        end
-
-        it 'returns status 200' do  
-            expect(response).to have_http_status 200
-        end
- 
-    end 
-
-    # spec for GET /ingredient_categories/:id
-    describe 'GET /ingredient_categories/:id' do
- 
-        before { get "/ingredient_categories/#{ingredient_category_id}" }
-
-        # expect a request for category id of :ingredient_category_id
-        context 'when the record exists' do
-            it 'returns the ingredient' do
-                expect(json).not_to be_empty
-                expect(json['id']).to eq ingredient_category_id
-            end
-
-            it 'returns status code 200' do
-                expect(response).to have_http_status 200
-            end
-        end
-    
-        context 'when the record does not exist' do
-            let(:ingredient_category_id) { 99 }
-
-            it 'returns status code 404' do
-                expect(response).to have_http_status 404
-            end
-
-            it 'returns not found message' do
-                expect(response.body).to match /Couldn't find IngredientCategory/
-            end
-        end    
- 
+    it 'returns ingredient_categories' do
+      expect(json).not_to be_empty
+      expect(json.size).to eq 10
     end
 
-    # spec for POST /ingredient_category
-    describe 'POST /ingredient_categories' do
+    it 'returns status 200' do  
+      expect(response).to have_http_status 200
+    end
+ 
+  end 
+
+  # spec for GET /ingredient_categories/:id
+  describe 'GET /ingredient_categories/:id' do
+ 
+    before { get "/ingredient_categories/#{ingredient_category_id}" }
+
+    # expect a request for category id of :ingredient_category_id
+    context 'when the record exists' do
+      it 'returns the ingredient' do
+        expect(json).not_to be_empty
+        expect(json['id']).to eq ingredient_category_id
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status 200
+      end
+    end
   
-        let(:valid_attributes) { {name: 'Dairy'} }
+    context 'when the record does not exist' do
+      let(:ingredient_category_id) { 99 }
 
-        context 'when request is valid' do
-            before { post '/ingredient_categories', params: valid_attributes}
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
 
-            it 'creates an ingredient category' do
-                expect( json['name'] ).to eq 'Dairy'
-            end
-
-            it 'returns status code 201' do
-                expect(response).to have_http_status 201
-            end
-        end
-
-        context 'when request is invalid' do
-            before { post '/ingredient_categories', params: { } }
-
-            it 'returns status code 422' do
-                expect(response).to have_http_status 422
-            end
-
-            it 'returns validation failure message' do
-                expect(response.body).to match /Validation failed: Name can't be blank/
-            end
-        end
+      it 'returns not found message' do
+        expect(response.body).to match /Couldn't find IngredientCategory/
+      end
+    end    
  
-    end
+  end
 
-
-    # spec for PUT /ingredient_category/:id
-    describe 'PUT /ingredient_categories/:id' do
-
-        let(:valid_attributes) { {name: 'Dairy'} } 
-
-        context 'when record exists' do
-            before { put "/ingredient_categories/#{ingredient_category_id}", params: valid_attributes}
-
-            it 'updates the record' do
-                expect(response.body).to be_empty
-            end
-
-            it 'returns status code 204' do
-                expect(response).to have_http_status 204
-            end
-        end
-
-    end
-
-    # spec for DELETE /ingredient_category/:id
-    describe 'DELETE /ingredient_categories/:id' do
-
-        before { delete "/ingredient_categories/#{ingredient_category_id}" }
-
-        it 'returns status code 204' do
-            expect(response).to have_http_status 204 
-        end
+  # spec for POST /ingredient_category
+  describe 'POST /ingredient_categories' do
   
+    let(:valid_attributes) { {name: 'Dairy'} }
+
+    context 'when request is valid' do
+      before { post '/ingredient_categories', params: valid_attributes}
+
+      it 'creates an ingredient category' do
+        expect( json['name'] ).to eq 'Dairy'
+      end
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status 201
+      end
     end
+
+    context 'when request is invalid' do
+      before { post '/ingredient_categories', params: { } }
+
+      it 'returns status code 422' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'returns validation failure message' do
+        expect(response.body).to match /Validation failed: Name can't be blank/
+      end
+    end
+ 
+  end
+
+
+  # spec for PUT /ingredient_category/:id
+  describe 'PUT /ingredient_categories/:id' do
+
+    let(:valid_attributes) { {name: 'Dairy'} } 
+
+    context 'when record exists' do
+      before { put "/ingredient_categories/#{ingredient_category_id}", params: valid_attributes}
+
+      it 'updates the record' do
+        expect(response.body).to be_empty
+      end
+
+      it 'returns status code 204' do
+        expect(response).to have_http_status 204
+      end
+    end
+
+  end
+
+  # spec for DELETE /ingredient_category/:id
+  describe 'DELETE /ingredient_categories/:id' do
+
+    before { delete "/ingredient_categories/#{ingredient_category_id}" }
+
+    it 'returns status code 204' do
+      expect(response).to have_http_status 204 
+    end
+  
+  end
 
 end
-    
+  

--- a/nourish_api/spec/requests/ingredients_spec.rb
+++ b/nourish_api/spec/requests/ingredients_spec.rb
@@ -12,11 +12,10 @@ RSpec.describe 'Ingredient API', type: :request do
 
     # spec for GET /ingredient_categories/:id/ingredients
     describe 'GET /ingredient_categories/:ingredient_category_id/ingredients' do
- 
+  
         before { get "/ingredient_categories/#{ingredient_category_id}/ingredients" }
 
-        context 'when category exists' do
-            
+        context 'when category exists' do          
             it 'returns status code 200' do
                 expect(response).to have_http_status 200 
             end
@@ -24,7 +23,6 @@ RSpec.describe 'Ingredient API', type: :request do
             it 'returns all ingredients in that category' do
                 expect(json.size).to eq 10
             end
-
         end
 
         context 'when category does not exist' do
@@ -38,7 +36,7 @@ RSpec.describe 'Ingredient API', type: :request do
                 expect(response.body).to match /Couldn't find IngredientCategory/
             end
         end
- 
+   
     end
 
     # spec for GET /ingredient_categories/:ingredient_category_id/ingredients/:id
@@ -81,7 +79,6 @@ RSpec.describe 'Ingredient API', type: :request do
             it 'returns status code 201' do
                 expect(response).to have_http_status 201
             end
-
         end
 
         context 'when request attributes are invalid' do
@@ -99,13 +96,12 @@ RSpec.describe 'Ingredient API', type: :request do
     end
 
     # spec for PUT /ingredient_categories/:ingredient_category_id/ingredients/:id
-    describe 'PUT /ingredients/:id' do
-        
+    describe 'PUT /ingredients/:id' do      
+
         let(:valid_attrs) { {name: 'Fishsticks'} }
         before { put "/ingredients/#{id}", params: valid_attrs }
 
         context 'when ingredient exists' do
-
             it 'returns status code 204' do
                 expect(response).to have_http_status 204
             end
@@ -114,12 +110,10 @@ RSpec.describe 'Ingredient API', type: :request do
                updated_ingredient = Ingredient.find(id)
                expect(updated_ingredient.name).to match /Fishsticks/ 
             end
-
         end
 
         context 'when ingredient does not exist' do
             let(:id) { 0 }
-
             it 'returns status code 404' do
                 expect(response).to have_http_status 404
             end
@@ -127,13 +121,13 @@ RSpec.describe 'Ingredient API', type: :request do
             it 'returns a not found message' do
                 expect(response.body).to match /Couldn't find Ingredient/
             end
-
         end
 
     end
 
     # spec for DELETE /ingredient_categories/:ingredient_category_id/ingredients/:id
     describe 'DELETE /ingredients/:id' do
+
         before { delete "/ingredients/#{id}"}
 
         it 'returns status code 204' do

--- a/nourish_api/spec/requests/ingredients_spec.rb
+++ b/nourish_api/spec/requests/ingredients_spec.rb
@@ -5,135 +5,135 @@
 require 'rails_helper'
 
 RSpec.describe 'Ingredient API', type: :request do
-    let!(:ingredient_category) { create(:ingredient_category) }
-    let!(:ingredients) { create_list(:ingredient, 10, ingredient_category_id: ingredient_category.id) }
-    let(:ingredient_category_id) { ingredient_category.id }
-    let(:id) { ingredients.first.id }
+  let!(:ingredient_category) { create(:ingredient_category) }
+  let!(:ingredients) { create_list(:ingredient, 10, ingredient_category_id: ingredient_category.id) }
+  let(:ingredient_category_id) { ingredient_category.id }
+  let(:id) { ingredients.first.id }
 
-    # spec for GET /ingredient_categories/:id/ingredients
-    describe 'GET /ingredient_categories/:ingredient_category_id/ingredients' do
+  # spec for GET /ingredient_categories/:id/ingredients
+  describe 'GET /ingredient_categories/:ingredient_category_id/ingredients' do
   
-        before { get "/ingredient_categories/#{ingredient_category_id}/ingredients" }
+    before { get "/ingredient_categories/#{ingredient_category_id}/ingredients" }
 
-        context 'when category exists' do          
-            it 'returns status code 200' do
-                expect(response).to have_http_status 200 
-            end
+    context 'when category exists' do          
+      it 'returns status code 200' do
+        expect(response).to have_http_status 200 
+      end
 
-            it 'returns all ingredients in that category' do
-                expect(json.size).to eq 10
-            end
-        end
-
-        context 'when category does not exist' do
-            let(:ingredient_category_id) { 0 }
-
-            it 'returns status code 404' do
-                expect(response).to have_http_status 404
-            end
-
-            it 'returns a not found message' do
-                expect(response.body).to match /Couldn't find IngredientCategory/
-            end
-        end
-   
+      it 'returns all ingredients in that category' do
+        expect(json.size).to eq 10
+      end
     end
 
-    # spec for GET /ingredient_categories/:ingredient_category_id/ingredients/:id
-    describe 'GET /ingredients/:id' do
+    context 'when category does not exist' do
+      let(:ingredient_category_id) { 0 }
+
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns a not found message' do
+        expect(response.body).to match /Couldn't find IngredientCategory/
+      end
+    end
+   
+  end
+
+  # spec for GET /ingredient_categories/:ingredient_category_id/ingredients/:id
+  describe 'GET /ingredients/:id' do
  
-        before { get "/ingredients/#{id}" }
+    before { get "/ingredients/#{id}" }
 
-        context 'when ingredient exists' do
-            it 'returns status code 200' do
-                expect(response).to have_http_status 200
-            end
-            
-            it 'returns the ingredient' do
-                expect(json['id']).to eq id
-            end
-        end
+    context 'when ingredient exists' do
+      it 'returns status code 200' do
+        expect(response).to have_http_status 200
+      end
+      
+      it 'returns the ingredient' do
+        expect(json['id']).to eq id
+      end
+    end
 
-        context 'when ingredient does not exist' do
-            let(:id) { 0 }
+    context 'when ingredient does not exist' do
+      let(:id) { 0 }
 
-            it 'returns status code 404' do
-                expect(response).to have_http_status 404
-            end
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
 
-            it 'returns a not found message' do
-                expect(response.body).to match /Couldn't find Ingredient/
-            end
-        end
+      it 'returns a not found message' do
+        expect(response.body).to match /Couldn't find Ingredient/
+      end
+    end
    
+  end
+
+  # spec for POST /ingredient_categories/:ingredient_category_id/ingredients
+  describe 'POST /ingredient_categories/:ingredient_category_id/ingredients' do
+  
+    let(:valid_attrs) { {name: 'milk'} }
+     
+    context 'when request attributes are valid' do
+      before { post "/ingredient_categories/#{ingredient_category_id}/ingredients", params: valid_attrs }
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status 201
+      end
     end
 
-    # spec for POST /ingredient_categories/:ingredient_category_id/ingredients
-    describe 'POST /ingredient_categories/:ingredient_category_id/ingredients' do
-    
-        let(:valid_attrs) { {name: 'milk'} }
-       
-        context 'when request attributes are valid' do
-            before { post "/ingredient_categories/#{ingredient_category_id}/ingredients", params: valid_attrs }
+    context 'when request attributes are invalid' do
+      before { post "/ingredient_categories/#{ingredient_category_id}/ingredients/", params: {} }
 
-            it 'returns status code 201' do
-                expect(response).to have_http_status 201
-            end
-        end
+      it 'returns status code 422' do
+        expect(response).to have_http_status 422
+      end
 
-        context 'when request attributes are invalid' do
-            before { post "/ingredient_categories/#{ingredient_category_id}/ingredients/", params: {} }
-
-            it 'returns status code 422' do
-                expect(response).to have_http_status 422
-            end
-
-            it 'returns a failure message' do
-                expect(response.body).to match /Validation failed: Name can't be blank/
-            end
-        end
+      it 'returns a failure message' do
+        expect(response.body).to match /Validation failed: Name can't be blank/
+      end
+    end
    
+  end
+
+  # spec for PUT /ingredient_categories/:ingredient_category_id/ingredients/:id
+  describe 'PUT /ingredients/:id' do      
+
+    let(:valid_attrs) { {name: 'Fishsticks'} }
+    before { put "/ingredients/#{id}", params: valid_attrs }
+
+    context 'when ingredient exists' do
+      it 'returns status code 204' do
+        expect(response).to have_http_status 204
+      end
+
+      it 'updates the ingredient' do
+         updated_ingredient = Ingredient.find(id)
+         expect(updated_ingredient.name).to match /Fishsticks/ 
+      end
     end
 
-    # spec for PUT /ingredient_categories/:ingredient_category_id/ingredients/:id
-    describe 'PUT /ingredients/:id' do      
+    context 'when ingredient does not exist' do
+      let(:id) { 0 }
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
 
-        let(:valid_attrs) { {name: 'Fishsticks'} }
-        before { put "/ingredients/#{id}", params: valid_attrs }
-
-        context 'when ingredient exists' do
-            it 'returns status code 204' do
-                expect(response).to have_http_status 204
-            end
-
-            it 'updates the ingredient' do
-               updated_ingredient = Ingredient.find(id)
-               expect(updated_ingredient.name).to match /Fishsticks/ 
-            end
-        end
-
-        context 'when ingredient does not exist' do
-            let(:id) { 0 }
-            it 'returns status code 404' do
-                expect(response).to have_http_status 404
-            end
-
-            it 'returns a not found message' do
-                expect(response.body).to match /Couldn't find Ingredient/
-            end
-        end
-
+      it 'returns a not found message' do
+        expect(response.body).to match /Couldn't find Ingredient/
+      end
     end
 
-    # spec for DELETE /ingredient_categories/:ingredient_category_id/ingredients/:id
-    describe 'DELETE /ingredients/:id' do
+  end
 
-        before { delete "/ingredients/#{id}"}
+  # spec for DELETE /ingredient_categories/:ingredient_category_id/ingredients/:id
+  describe 'DELETE /ingredients/:id' do
 
-        it 'returns status code 204' do
-            expect(response).to have_http_status 204
-        end
+    before { delete "/ingredients/#{id}"}
 
+    it 'returns status code 204' do
+      expect(response).to have_http_status 204
     end
+
+  end
 
 end

--- a/nourish_api/spec/requests/ingredients_spec.rb
+++ b/nourish_api/spec/requests/ingredients_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Ingredient API', type: :request do
    
   end
 
-  # spec for GET /ingredient_categories/:ingredient_category_id/ingredients/:id
+  # spec for GET /ingredients/:id
   describe 'GET /ingredients/:id' do
  
     before { get "/ingredients/#{id}" }
@@ -95,7 +95,7 @@ RSpec.describe 'Ingredient API', type: :request do
    
   end
 
-  # spec for PUT /ingredient_categories/:ingredient_category_id/ingredients/:id
+  # spec for PUT /ingredients/:id
   describe 'PUT /ingredients/:id' do      
 
     let(:valid_attrs) { {name: 'Fishsticks'} }
@@ -125,7 +125,7 @@ RSpec.describe 'Ingredient API', type: :request do
 
   end
 
-  # spec for DELETE /ingredient_categories/:ingredient_category_id/ingredients/:id
+  # spec for DELETE /ingredients/:id
   describe 'DELETE /ingredients/:id' do
 
     before { delete "/ingredients/#{id}"}

--- a/nourish_api/spec/requests/ingredients_spec.rb
+++ b/nourish_api/spec/requests/ingredients_spec.rb
@@ -1,0 +1,145 @@
+# ingredient request spec
+# /spec/requests/ingredients_spec.rb
+# test methods adapted from https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one
+
+require 'rails_helper'
+
+RSpec.describe 'Ingredient API', type: :request do
+    let!(:ingredient_category) { create(:ingredient_category) }
+    let!(:ingredients) { create_list(:ingredient, 10, ingredient_category_id: ingredient_category.id) }
+    let(:ingredient_category_id) { ingredient_category.id }
+    let(:id) { ingredients.first.id }
+
+    # spec for GET /ingredient_categories/:id/ingredients
+    describe 'GET /ingredient_categories/:ingredient_category_id/ingredients' do
+ 
+        before { get "/ingredient_categories/#{ingredient_category_id}/ingredients" }
+
+        context 'when category exists' do
+            
+            it 'returns status code 200' do
+                expect(response).to have_http_status 200 
+            end
+
+            it 'returns all ingredients in that category' do
+                expect(json.size).to eq 10
+            end
+
+        end
+
+        context 'when category does not exist' do
+            let(:ingredient_category_id) { 0 }
+
+            it 'returns status code 404' do
+                expect(response).to have_http_status 404
+            end
+
+            it 'returns a not found message' do
+                expect(response.body).to match /Couldn't find IngredientCategory/
+            end
+        end
+ 
+    end
+
+    # spec for GET /ingredient_categories/:ingredient_category_id/ingredients/:id
+    describe 'GET /ingredients/:id' do
+ 
+        before { get "/ingredients/#{id}" }
+
+        context 'when ingredient exists' do
+            it 'returns status code 200' do
+                expect(response).to have_http_status 200
+            end
+            
+            it 'returns the ingredient' do
+                expect(json['id']).to eq id
+            end
+        end
+
+        context 'when ingredient does not exist' do
+            let(:id) { 0 }
+
+            it 'returns status code 404' do
+                expect(response).to have_http_status 404
+            end
+
+            it 'returns a not found message' do
+                expect(response.body).to match /Couldn't find Ingredient/
+            end
+        end
+   
+    end
+
+    # spec for POST /ingredient_categories/:ingredient_category_id/ingredients
+    describe 'POST /ingredient_categories/:ingredient_category_id/ingredients' do
+    
+        let(:valid_attrs) { {name: 'milk'} }
+       
+        context 'when request attributes are valid' do
+            before { post "/ingredient_categories/#{ingredient_category_id}/ingredients", params: valid_attrs }
+
+            it 'returns status code 201' do
+                expect(response).to have_http_status 201
+            end
+
+        end
+
+        context 'when request attributes are invalid' do
+            before { post "/ingredient_categories/#{ingredient_category_id}/ingredients/", params: {} }
+
+            it 'returns status code 422' do
+                expect(response).to have_http_status 422
+            end
+
+            it 'returns a failure message' do
+                expect(response.body).to match /Validation failed: Name can't be blank/
+            end
+        end
+   
+    end
+
+    # spec for PUT /ingredient_categories/:ingredient_category_id/ingredients/:id
+    describe 'PUT /ingredients/:id' do
+        
+        let(:valid_attrs) { {name: 'Fishsticks'} }
+        before { put "/ingredients/#{id}", params: valid_attrs }
+
+        context 'when ingredient exists' do
+
+            it 'returns status code 204' do
+                expect(response).to have_http_status 204
+            end
+
+            it 'updates the ingredient' do
+               updated_ingredient = Ingredient.find(id)
+               expect(updated_ingredient.name).to match /Fishsticks/ 
+            end
+
+        end
+
+        context 'when ingredient does not exist' do
+            let(:id) { 0 }
+
+            it 'returns status code 404' do
+                expect(response).to have_http_status 404
+            end
+
+            it 'returns a not found message' do
+                expect(response.body).to match /Couldn't find Ingredient/
+            end
+
+        end
+
+    end
+
+    # spec for DELETE /ingredient_categories/:ingredient_category_id/ingredients/:id
+    describe 'DELETE /ingredients/:id' do
+        before { delete "/ingredients/#{id}"}
+
+        it 'returns status code 204' do
+            expect(response).to have_http_status 204
+        end
+
+    end
+
+end

--- a/nourish_api/spec/support/request_spec_helper.rb
+++ b/nourish_api/spec/support/request_spec_helper.rb
@@ -1,0 +1,12 @@
+# request spec helpers
+# /spec/support/request_spec_helper.rb
+# source: https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one
+
+module RequestSpecHelper
+
+    # create json method to shorten JSON.parse syntax
+    def json
+        JSON.parse(response.body)
+    end
+
+end

--- a/nourish_api/spec/support/request_spec_helper.rb
+++ b/nourish_api/spec/support/request_spec_helper.rb
@@ -4,9 +4,9 @@
 
 module RequestSpecHelper
 
-    # create json method to shorten JSON.parse syntax
-    def json
-        JSON.parse(response.body)
-    end
+  # create json method to shorten JSON.parse syntax
+  def json
+    JSON.parse(response.body)
+  end
 
 end


### PR DESCRIPTION
Removing deprecated `should` syntax for Ingredient and IngredientCategory model unit tests, replaced with `is_expected.to`