### PR TITLE
adding GET /ingredients route, serializing models

### DIFF
--- a/nourish_api/Gemfile
+++ b/nourish_api/Gemfile
@@ -25,6 +25,9 @@ gem 'devise'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# active-model-serializer for effectively nesting JSON responses
+gem 'active_model_serializers'
+
 # A plugin for versioning Rails based RESTful APIs.
 gem 'versionist'
 

--- a/nourish_api/Gemfile.lock
+++ b/nourish_api/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.1.6)
       activesupport (= 5.1.6)
       globalid (>= 0.3.6)
@@ -42,6 +47,8 @@ GEM
     bcrypt (3.1.11)
     builder (3.2.3)
     byebug (10.0.2)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     database_cleaner (1.6.2)
@@ -65,6 +72,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-inotify (~> 0.9, >= 0.9.7)
     loofah (2.2.2)
@@ -108,6 +116,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
+    rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     responders (2.4.0)
@@ -130,6 +139,7 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
+    ruby_dep (1.5.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     spring (2.0.2)
@@ -163,6 +173,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   byebug
   database_cleaner
   devise
@@ -173,7 +184,9 @@ DEPENDENCIES
   puma (~> 3.7)
   rack-cors
   rails (~> 5.1.6)
+  rb-fsevent
   rspec-rails (~> 3.5)
+  ruby_dep
   shoulda-matchers (~> 3.1)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/nourish_api/app/controllers/ingredients_controller.rb
+++ b/nourish_api/app/controllers/ingredients_controller.rb
@@ -3,12 +3,19 @@
 
 class IngredientsController < ApplicationController
 
-  before_action :set_ingredient_category, only: [:index, :create]
   before_action :set_ingredient, only: [:show, :update, :destroy]
 
-  # GET /ingredient_categories/:ingredient_category_id/ingredients/
   def index
-    render json: @ingredientcategory.ingredients, status: :ok
+    # GET /ingredient_categories/:ingredient_category_id/ingredients/
+    if params[:ingredient_category_id]
+      set_ingredient_category()
+      render json: @ingredientcategory.ingredients, status: :ok
+    
+    # GET /ingredients
+    else
+      @ingredients = Ingredient.all
+      render json: @ingredients, status: :ok
+    end
   end
 
   # GET /ingredients/:id
@@ -18,6 +25,7 @@ class IngredientsController < ApplicationController
 
   # POST /ingredient_categories/:ingredient_category_id/ingredients/
   def create 
+    set_ingredient_category()
     @ingredientcategory.ingredients.create!(ingredient_params)
     render json: @ingredientcategory, status: :created
   end

--- a/nourish_api/app/serializers/ingredient_category_serializer.rb
+++ b/nourish_api/app/serializers/ingredient_category_serializer.rb
@@ -1,0 +1,6 @@
+# app/serializers/ingredient_category_serializer.rb
+# IngredientCategory model serializer
+
+class IngredientCategorySerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/nourish_api/app/serializers/ingredient_serializer.rb
+++ b/nourish_api/app/serializers/ingredient_serializer.rb
@@ -1,0 +1,7 @@
+# app/serializers/ingredient_serializer.rb
+# Ingredient model serializer
+
+class IngredientSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  has_one :ingredient_category 
+end

--- a/nourish_api/config/routes.rb
+++ b/nourish_api/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :ingredients, only: [:index, :create]
   end
 
-  resources :ingredients, only: [:show, :update, :destroy]
+  resources :ingredients, only: [:index, :show, :update, :destroy]
 
   # set up dietary_restrictions routes
   resources :dietary_restrictions

--- a/nourish_api/spec/requests/ingredients_spec.rb
+++ b/nourish_api/spec/requests/ingredients_spec.rb
@@ -8,7 +8,32 @@ RSpec.describe 'Ingredient API', type: :request do
   let!(:ingredient_category) { create(:ingredient_category) }
   let!(:ingredients) { create_list(:ingredient, 10, ingredient_category_id: ingredient_category.id) }
   let(:ingredient_category_id) { ingredient_category.id }
+  let(:ingredient_category_name) { ingredient_category.name }
   let(:id) { ingredients.first.id }
+
+  describe 'GET /ingredients' do
+
+    before { get "/ingredients" }
+    
+    context 'when ingredients are in database' do
+      it 'returns status code 200' do
+        expect(response).to have_http_status 200
+      end
+   
+      it 'returns all ingredients' do
+        expect(json.size).to eq 10
+      end
+
+      it 'returns ingredient categories' do
+        json.each do |ingredient|
+          category = ingredient['ingredient_category']
+          expect(category['name']).to eq ingredient_category_name
+          expect(category['id']).to eq ingredient_category_id
+        end
+      end
+    end
+
+  end
 
   # spec for GET /ingredient_categories/:id/ingredients
   describe 'GET /ingredient_categories/:ingredient_category_id/ingredients' do


### PR DESCRIPTION
• Added GET /ingredients that returns all ingredients as follows:
[
  {
  "id": (id)
  "ingredient_category":  {  "id": (id), "name": (category name)  },
  "name": (ingredient name)
  }, 
  ...
]

• Serialized Ingredient and IngredientCategory models: 
-- Removed timestamp-related data.
-- Allowed retrieval of nested (id, name) of each Ingredient's IngredientCategory.