### PR TITLE
User Model + Devise + Unit Tests

### DIFF
--- a/nourish_api/app/controllers/application_controller.rb
+++ b/nourish_api/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
+# ApplicationController
+# /app/controllers/application_controller.rb
+
 class ApplicationController < ActionController::API
+   
   include DeviseTokenAuth::Concerns::SetUserByToken
   include ExceptionHandler
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+    # permit additional parameters for user sign up and account updates 
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :image, :email, :default_servings])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :first_name, :last_name, :image, :email, :default_servings])
+    end
+
 end

--- a/nourish_api/app/controllers/concerns/exception_handler.rb
+++ b/nourish_api/app/controllers/concerns/exception_handler.rb
@@ -7,7 +7,6 @@ module ExceptionHandler
   extend ActiveSupport::Concern
 
   included do 
-
     # handle 'record not found' errors
     # return error message+ '404'
     rescue_from ActiveRecord::RecordNotFound do |e|

--- a/nourish_api/app/controllers/dietary_restrictions_controller.rb
+++ b/nourish_api/app/controllers/dietary_restrictions_controller.rb
@@ -1,4 +1,4 @@
-# DiectaryRestrictions controller
+# DietaryRestrictions controller
 # /app/controllers/dietary_restrictions_controller.rb
 
 class DietaryRestrictionsController < ApplicationController

--- a/nourish_api/app/controllers/recipes_controller.rb
+++ b/nourish_api/app/controllers/recipes_controller.rb
@@ -1,11 +1,15 @@
+# Recipes controller
+# /app/controllers/recipes_controller.rb
+
 class RecipesController < ApplicationController
 
   before_action :set_recipe, only: [:show, :update, :destroy]
- # before_action :authenticate_user!, only: [:create, :update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   # GET /recipes (public only) --> do search with query params
   # GET /users/:id/recipes
   def index
+    
     if params[:user_id]
       set_user()
       render json: @user.recipes, status: :ok
@@ -13,6 +17,7 @@ class RecipesController < ApplicationController
       @recipes = Recipe.all
       render json: @recipes, status: :ok
     end
+    
   end
 
   # GET /recipes/:id

--- a/nourish_api/app/controllers/users_controller.rb
+++ b/nourish_api/app/controllers/users_controller.rb
@@ -1,33 +1,28 @@
+# Users controller
+# /app/controllers/users_controller.rb
+
 class UsersController < ApplicationController
 
- # before_action :authenticate_user!
+  # NOTE: create, delete, put actions all handled by devise_token_auth
+
+  before_action :authenticate_user!
 
   # GET /users
   def index
-  @users = User.all()
-  render json: @users, status: :ok
+    @users = User.all()
+    render json: @users, each_serializer: AbbrevUserSerializer, status: :ok
   end
 
   # GET /users/:id
   def show 
     set_user()
-    render json: @user, status: :ok
-  end
-
-  # POST /users
-  def create
-    @user = User.create!(user_params)
-    render json: @user, status: :created
-  end
-
-  # PUT /users/:id
-  def update
-    
-  end
-
-  # DELETE /users/:id
-  def destroy
-    
+    if( (current_user.id).to_s == ( params[:id]).to_s )
+      # allow expanded user data for current user
+      render json: @user, serializer: CompleteUserSerializer, status: :ok
+    else
+      # restrict data shown about other users
+      render json: @user, serializer: AbbrevUserSerializer, status: :ok
+    end
   end
 
   private

--- a/nourish_api/app/serializers/abbrev_user_serializer.rb
+++ b/nourish_api/app/serializers/abbrev_user_serializer.rb
@@ -1,0 +1,6 @@
+# AbbrevUserSerializer: abbreviated user data
+# app/serializers/abbrev_user_serializer.rb
+
+class AbbrevUserSerializer < ActiveModel::Serializer
+  attributes :nickname
+end

--- a/nourish_api/app/serializers/complete_user_serializer.rb
+++ b/nourish_api/app/serializers/complete_user_serializer.rb
@@ -1,0 +1,6 @@
+# app/models/serializers/complete_user_serializer.rb
+# User model serializer (admin / authenticated view)
+
+class CompleteUserSerializer < AbbrevUserSerializer
+  attributes :first_name, :last_name, :email, :default_servings, :image, :nickname
+end

--- a/nourish_api/app/serializers/recipe_serializer.rb
+++ b/nourish_api/app/serializers/recipe_serializer.rb
@@ -5,5 +5,5 @@ class RecipeSerializer < ActiveModel::Serializer
   attributes :id, :title, :summary, :instructions
   has_many :ingredient_recipes
   has_many :dietary_restrictions
-  has_one :user
+  has_one :user, :serializer => AbbrevUserSerializer
 end

--- a/nourish_api/app/serializers/user_serializer.rb
+++ b/nourish_api/app/serializers/user_serializer.rb
@@ -1,6 +1,0 @@
-# app/models/serializers/user_serializer.rb
-# User model serializer (non-admin / authenticated view)
-
-class UserSerializer < ActiveModel::Serializer
-  attributes :id, :nickname
-end

--- a/nourish_api/config/initializers/devise_token_auth.rb
+++ b/nourish_api/config/initializers/devise_token_auth.rb
@@ -3,7 +3,10 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+
+  # let's just do this for now - keep identical tokens across user requests,
+  # after authentication
+   config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.

--- a/nourish_api/config/routes.rb
+++ b/nourish_api/config/routes.rb
@@ -21,13 +21,11 @@ Rails.application.routes.draw do
 
   # set up users / recipes
   # (1 user : m recipes)
-  resources :users do
+  resources :users, only: [:index, :show] do
     resources :recipes, only: [:index, :create]
   end
   # allow GET /recipes as well
   resources :recipes, only: [:index, :show, :update, :destroy]
 
-
-  
 end
 

--- a/nourish_api/spec/factories/users.rb
+++ b/nourish_api/spec/factories/users.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :user do
+    nickname { Faker::VentureBros::character }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     email { Faker:: Internet.email }

--- a/nourish_api/spec/rails_helper.rb
+++ b/nourish_api/spec/rails_helper.rb
@@ -72,6 +72,9 @@ RSpec.configure do |config|
   # add `FactoryBot` methods
   config.include FactoryBot::Syntax::Methods
 
+  # add auth helper method for requests
+  config.include AuthHelper::Request, type: :request
+
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/nourish_api/spec/requests/recipes_spec.rb
+++ b/nourish_api/spec/requests/recipes_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe 'Recipes API', type: :request do
   let(:num_restrictions) { 0 }
 
   let!(:user_1) { create(:user) } 
+  subject { auth_post user_1, '/auth', params: {  email: user_1.email,
+                                                password: user_1.password,
+                                                password_confirmation: user_1.password, 
+                                                confirm_success_url: "www.google.com" } }
+
+  
+
   let!(:user_2) { create(:user) }
 
   let!(:uid_1) { user_1.id }
@@ -28,7 +35,8 @@ RSpec.describe 'Recipes API', type: :request do
   #
 
   describe "GET /users/:id/recipes" do
-    before { get "/users/#{uid_1}/recipes" }
+    before { auth_get user_1, "/users/#{user_1.id}/recipes", params: {} }
+  #  before { get "/users/#{uid_1}/recipes", headers: user_1.headers }
 
     context 'when recipes are in database' do
     
@@ -143,7 +151,7 @@ RSpec.describe 'Recipes API', type: :request do
                       }
      
     context 'when request attributes are valid' do
-      before { post "/users/#{uid_1}/recipes", params: valid_attrs }
+      before { auth_post user_1, "/users/#{user_1.id}/recipes", params: valid_attrs }
 
       it 'returns status code 201' do
         expect(response).to have_http_status 201
@@ -151,7 +159,7 @@ RSpec.describe 'Recipes API', type: :request do
     end
 
     context 'when request attributes are invalid' do
-      before { post "/users/#{uid_1}/recipes", params: {} }
+      before { auth_post user_1, "/users/#{user_1.id}/recipes", params: {} }
 
       it 'returns status code 400' do
         expect(response).to have_http_status 400
@@ -168,7 +176,7 @@ RSpec.describe 'Recipes API', type: :request do
   describe "PUT /recipes" do
 
     let(:valid_attrs) { { recipe: { title: 'croque monsieur' } } }
-    before { put "/recipes/#{id}", params: valid_attrs }
+    before { auth_put user_1, "/recipes/#{id}", params: valid_attrs }
 
     context 'when recipe exists' do
       it 'returns status code 204' do
@@ -202,7 +210,7 @@ RSpec.describe 'Recipes API', type: :request do
 
   describe 'DELETE /recipes/:id' do
 
-    before { delete "/recipes/#{id}"}
+    before { auth_delete user_1, "/recipes/#{id}", params: {} }
 
     it 'returns status code 204' do
       expect(response).to have_http_status 204

--- a/nourish_api/spec/requests/users_spec.rb
+++ b/nourish_api/spec/requests/users_spec.rb
@@ -1,0 +1,147 @@
+# spec/requests/users_spec.rb
+# User request specs (incl. Devise / auth)
+
+include ActionController::RespondWith
+
+require 'rails_helper'
+require 'support/request_spec_helper'
+require 'json'
+
+RSpec.describe 'Users API', type: :request do
+
+  before(:each) do
+    @user = create(:user)
+    auth_post @user, "/auth", params: {  nickname: @user.nickname,
+                                         email: @user.email,
+                                         password: @user.password,
+                                         password_confirmation: @user.password, 
+                                         confirm_success_url: "www.google.com" }
+  end
+  
+  context 'signing in the user' do
+    before { auth_post @user, '/auth/sign_in', params: { email: @user.email, password: @user.password } }
+
+    it 'gives status code of 200 on signin' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'gives you an auth code if you are existing user / satisfy password' do
+      expect(response.has_header?('access-token')).to eq(true)
+    end
+    
+  end # end context
+
+  context 'getting all user information (GET /users)' do
+    before { auth_post @user, '/auth/sign_in', params: { email: @user.email, password: @user.password } }
+
+    it 'produces correct number of users from /users query' do
+      auth_get @user, '/users', params: {}
+      expect(json.size).to eq 1 # only one user      
+    end 
+
+    it 'produces abbreviated information (no specifics)' do
+      auth_get @user, '/users', params: {}
+      expect(json.first).to_not have_key("email")
+    end
+
+  end # end context
+
+  context 'getting one user\'s information (GET /users/:id)' do
+    before { auth_post @user, '/auth/sign_in', params: { email: @user.email, password: @user.password } }
+    
+    it 'returns status code 200 if user is authenticated' do
+      auth_get @user, "/users/#{@user.id}", params: {}
+      expect(response).to have_http_status(200)
+    end
+
+    it 'produces expanded info when user id matches current_user' do
+      auth_get @user, "/users/#{@user.id}", params: {}
+      expect(json).to have_key("email")
+    end
+
+    it 'produces abbreviated info when user id does not match current_user' do
+      @new_user = create(:user)
+      auth_get @user, "/users/#{@new_user.id}", params: {}
+      expect(json).to_not have_key("email") 
+    end
+
+    it 'returns status code 401 if user is not authenticated' do
+      get "/users/#{@user.id}" 
+      expect(response).to have_http_status(401)
+    end
+
+    it 'returns status code 404 if user does not exist' do
+      get "/users/-1" 
+      expect(response).to have_http_status(401)
+    end
+
+
+
+  end # end context
+
+  context 'modifying user account (PUT /auth)' do
+    before { auth_post @user, '/auth/sign_in', params: { email: @user.email, password: @user.password } }
+
+    it 'responds with status code 200' do
+      auth_put @user, "/auth", params: { nickname: "foobar" }
+      expect(response).to have_http_status 200
+    end
+
+    it 'allows user to modify their nickname' do
+      new_name = "l33thx"
+      auth_put @user, "/auth", params: { nickname: new_name }
+      expect(json["data"]["nickname"]).to eq new_name
+    end
+
+    it 'allows user to modify their email' do
+      new_email = "l33thx@gmail.com"
+      auth_put @user, "/auth", params: { email: new_email }
+      expect(json["data"]["email"]).to eq new_email
+    end
+
+    it 'returns status code 404 if user is not authenticated' do
+      put "/auth", params: { nickname: "randy" } 
+      expect(response).to have_http_status(404)
+    end
+    
+  end # end context
+
+  context 'deleting user account (DELETE /auth)' do
+    before { auth_post @user, '/auth/sign_in', params: { email: @user.email, password: @user.password } }
+    let!(:access_token) { response.header["access-token" ] }
+    let!(:client) { response.header["client"] }
+    let!(:uid) { response.header["uid"] }
+
+    it 'produces status code of 200 on successful deletion' do
+      auth_delete @user, "/auth", params: {  }
+      expect(response).to have_http_status 200
+    end
+
+    it 'allows user to delete their account' do
+      auth_delete @user, "/auth", params: {  }
+      get "/users/#{@user.id}", params: { }
+      expect(response).to have_http_status 401
+    end
+
+  end # end context
+
+  context 'signing out (DELETE /auth/sign_out)' do
+    before { auth_post @user, '/auth/sign_in', params: { email: @user.email, password: @user.password } }
+    let!(:access_token) { response.header["access-token" ] }
+    let!(:client) { response.header["client"] }
+    let!(:uid) { response.header["uid"] }
+
+    it 'produces status code of 200 0n successful signout' do
+      auth_delete @user, '/auth/sign_out', headers: { "access-token" => :access_token, "client" => :client, "uid" => :uid }
+      expect(response).to have_http_status 200
+    end 
+
+    it 'allows user to sign out' do
+      auth_delete @user, '/auth/sign_out', headers: { "access-token" => :access_token, "client" => :client, "uid" => :uid }
+      put '/auth', params: { nickname: "shouldn't work" }, headers: { "access-token" => :access_token, "client" => :client, "uid" => :uid }
+      expect(response).to have_http_status 404
+    end
+
+
+  end # end context
+end # end describe

--- a/nourish_api/spec/requests/users_spec.rb
+++ b/nourish_api/spec/requests/users_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe 'Users API', type: :request do
       expect(response).to have_http_status(401)
     end
 
-
-
   end # end context
 
   context 'modifying user account (PUT /auth)' do

--- a/nourish_api/spec/support/auth_helper.rb
+++ b/nourish_api/spec/support/auth_helper.rb
@@ -1,0 +1,21 @@
+# auth helper methods for unit testing
+# adapted from: https://github.com/lynndylanhurley/devise_token_auth/issues/521
+
+module AuthHelper
+
+    # Request helper: creates user auth tokens, builds + makes request
+    module Request
+        %i(get post put delete).each do |http_method|
+
+            # define method for each of these HTTP request types, fills http header / body
+            # with data, sends it to specified endpoint / action:
+            define_method("auth_#{http_method}") do |user, action_name, params: {}, headers: {}|
+              auth_headers = user.create_new_auth_token
+              headers = headers.merge(auth_headers)
+              public_send(http_method, action_name, params: params, headers: headers)
+            end
+
+        end
+
+    end
+end


### PR DESCRIPTION
Added:

* Support for devise_token_auth via /auth endpoints, which include:
  -- user sign-in via POST /auth/sign_in
  -- user sign-out via DELETE /auth/sign_out
  -- account creation  via POST /auth
  -- account deletion via DELETE /auth
  -- account modification via PUT /auth
  -- (See here: [https://maicolben.gitbooks.io/devise-token-auth/content/docs/usage/](https://maicolben.gitbooks.io/devise-token-auth/content/docs/usage/) )

* Authentication requirements for GET /users, GET /users/:id 
* Authentication requirements for GET /users/recipes, POST /users/recipes, PUT /users/recipes
* Unit tests for Devise + User model

TODO (for future PRs): 
* Add "public" boolean field to User database, and only allow for public recipes to be searched for / retrieved by unauthorized / unauthenticated users. 