### PR TITLE
Meal Plans, Recipe touch-ups

### DIFF
--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -27,12 +27,16 @@ class MealPlansController < ApplicationController
 
   # POST /users/:id/meal_plans
   def create
-    @meal_plan = @user.meal_plans.create!(meal_plan_params)
-    if @meal_plan.persisted?
-      render json: @meal_plan, status: :created
+    if @user == current_user
+      @meal_plan = @user.meal_plans.create!(meal_plan_params)
+      if @meal_plan.persisted?
+        render json: @meal_plan, status: :created
+      else
+        render status: :not_found
+      end
     else
-      render status: :not_found
-    end
+      render status: :unauthorized
+    end 
   end
 
   # PUT /meal_plans/:id

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -1,3 +1,6 @@
+# MealPlans controller
+# /app/controllers/meal_plans_controller.rb
+
 class MealPlansController < ApplicationController
 
   before_action :authenticate_user!  

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -1,28 +1,55 @@
 class MealPlansController < ApplicationController
-  
+
+  before_action :authenticate_user!  
   before_action :set_user, only: [:index, :create]
   before_action :set_meal_plan, only: [:show, :update, :destroy]
-  before_action :authenticate_user!, only: [:index, :show, :create, :update, :destroy]
 
   # GET /users/:id/meal_plans
   def index
-    render json: @user.meal_plans, status: :ok
+    if @user == current_user
+      render json: @user.meal_plans, status: :ok
+    else 
+      render status: :unauthorized
+    end 
   end
 
+  # GET /meal_plans/:id
   def show
-
+    if @meal_plan.user == current_user
+      render json: @meal_plan, status: :ok
+    else
+      render status: :unauthorized
+    end 
   end 
 
+  # POST /users/:id/meal_plans
   def create
-
+    @meal_plan = @user.meal_plans.create!(meal_plan_params)
+    if @meal_plan.persisted?
+      render json: @meal_plan, status: :created
+    else
+      render status: :not_found
+    end
   end
 
+  # PUT /meal_plans/:id
   def update
-
+    if @meal_plan.user == current_user
+      @meal_plan.update(meal_plan_params)
+      head :no_content    
+    else
+      render status: :unauthorized
+    end 
   end 
 
+  # DELETE /meal_plans/:id
   def destroy
-
+    if @meal_plan.user == current_user
+      @meal_plan.destroy
+      head :no_content
+    else
+      render status: :unauthorized
+    end
   end 
 
   private

--- a/app/controllers/meal_plans_controller.rb
+++ b/app/controllers/meal_plans_controller.rb
@@ -1,0 +1,43 @@
+class MealPlansController < ApplicationController
+  
+  before_action :set_user, only: [:index, :create]
+  before_action :set_meal_plan, only: [:show, :update, :destroy]
+  before_action :authenticate_user!, only: [:index, :show, :create, :update, :destroy]
+
+  # GET /users/:id/meal_plans
+  def index
+    render json: @user.meal_plans, status: :ok
+  end
+
+  def show
+
+  end 
+
+  def create
+
+  end
+
+  def update
+
+  end 
+
+  def destroy
+
+  end 
+
+  private
+
+    # define acceptable params for post, patch
+    def meal_plan_params
+      params.require(:meal_plan).permit(:name, meal_plan_recipes_attributes:[:recipe_id, :day, :meal] )
+    end
+
+    def set_user
+      @user = User.find(params[:user_id])
+    end
+
+    def set_meal_plan
+      @meal_plan = MealPlan.find(params[:id])
+    end
+
+end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -27,12 +27,16 @@ class RecipesController < ApplicationController
   # POST /users/:id/recipes
   def create
     set_user()
-    @recipe = @user.recipes.create!(recipe_params)
-    if @recipe.persisted?
-      render json: @recipe, status: :created
-    else
-      render status: :not_found
-    end
+    if @user == current_user
+      @recipe = @user.recipes.create!(recipe_params)
+      if @recipe.persisted?
+        render json: @recipe, status: :created
+      else
+        render status: :not_found
+      end
+    else 
+      render status: :unauthorized
+    end 
   end
 
   # PUT /recipes/:id

--- a/app/models/meal_plan.rb
+++ b/app/models/meal_plan.rb
@@ -7,4 +7,11 @@ class MealPlan < ApplicationRecord
   # meal plan has a 1:m relationship with user
   belongs_to :user
 
+  # describe m:n relationship between meal plans and recipes
+  has_many :meal_plan_recipes, dependent: :destroy
+  has_many :recipes, :through => :meal_plan_recipes
+
+  # allow meal_plan model to create meal_plan_recipes
+  accepts_nested_attributes_for :meal_plan_recipes
+
 end

--- a/app/models/meal_plan_recipe.rb
+++ b/app/models/meal_plan_recipe.rb
@@ -1,5 +1,13 @@
 class MealPlanRecipe < ApplicationRecord
 
+    belongs_to :recipe
+    belongs_to :meal_plan
+    validates_presence_of :day, :meal
+
+    enum day: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
+    enum meal: [:breakfast, :lunch, :dinner, :snack]
     
+    # combination of meal_plan_id, recipe_id, day, meal must be unique
+    validates_uniqueness_of :meal_plan_id, :scope => [:recipe_id, :day, :meal]
 
 end

--- a/app/models/meal_plan_recipe.rb
+++ b/app/models/meal_plan_recipe.rb
@@ -1,0 +1,5 @@
+class MealPlanRecipe < ApplicationRecord
+
+    
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ActiveRecord::Base
   # if a user is deleted, also delete associated recipes
   has_many :recipes, dependent: :destroy
 
+  # if a user is deleted, also delete associated meal_plans
+  has_many :meal_plans, dependent: :destroy
+
   # user nicknames must be unique
   validates_uniqueness_of :nickname
 

--- a/app/serializers/abbrev_recipe_serializer.rb
+++ b/app/serializers/abbrev_recipe_serializer.rb
@@ -1,0 +1,7 @@
+# app/models/serializers/abbrev_recipe_serializer.rb
+# Abbreviated Recipe serializer
+
+class AbbrevRecipeSerializer < ActiveModel::Serializer
+  attributes :id, :title
+end
+  

--- a/app/serializers/meal_plan_recipe_serializer.rb
+++ b/app/serializers/meal_plan_recipe_serializer.rb
@@ -1,5 +1,5 @@
 class MealPlanRecipeSerializer < ActiveModel::Serializer
   attributes :id, :day, :meal
   has_one :recipe, :serializer => ShortIngredientSerializer
-  has_one :meal_plan, :serializer => MeaplPlanSerializer
+  has_one :meal_plan, :serializer => MealPlanSerializer
 end

--- a/app/serializers/meal_plan_recipe_serializer.rb
+++ b/app/serializers/meal_plan_recipe_serializer.rb
@@ -1,0 +1,5 @@
+class MealPlanRecipeSerializer < ActiveModel::Serializer
+  attributes :id, :day, :meal
+  has_one :recipe, :serializer => ShortIngredientSerializer
+  has_one :meal_plan, :serializer => MeaplPlanSerializer
+end

--- a/app/serializers/meal_plan_recipe_serializer.rb
+++ b/app/serializers/meal_plan_recipe_serializer.rb
@@ -1,5 +1,5 @@
 class MealPlanRecipeSerializer < ActiveModel::Serializer
   attributes :id, :day, :meal
-  has_one :recipe, :serializer => ShortIngredientSerializer
-  has_one :meal_plan, :serializer => MealPlanSerializer
+  has_one :recipe, :serializer => AbbrevRecipeSerializer
+#  has_one :meal_plan, :serializer => MealPlanSerializer
 end

--- a/app/serializers/meal_plan_serializer.rb
+++ b/app/serializers/meal_plan_serializer.rb
@@ -1,0 +1,3 @@
+class MealPlanSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/meal_plan_serializer.rb
+++ b/app/serializers/meal_plan_serializer.rb
@@ -1,3 +1,5 @@
 class MealPlanSerializer < ActiveModel::Serializer
   attributes :id, :name
+  has_many :meal_plan_recipes
+  has_one :user, :serializer => AbbrevUserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,14 +20,19 @@ Rails.application.routes.draw do
   # set up dietary_restrictions routes
   resources :dietary_restrictions
 
-  # set up users / recipes
+  # set up users + recipes, meal_plans
   # (1 user : m recipes)
+  # (1 user : m meal_plans )
   resources :users, only: [:index, :show] do
     resources :recipes, only: [:index, :create]
+    resources :meal_plans, only: [:index, :create]
   end
   
   # allow GET /recipes as well
   resources :recipes, only: [:index, :update, :destroy]
+
+  # allow PUT / DELETE meal_plans
+  resources :meal_plans, only: [:update, :destroy]
 
   # specify exact form of GET /recipes/:id to avoid conflict with /search 
   # :id can only contain digits

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,18 +31,18 @@ Rails.application.routes.draw do
   # allow GET /recipes as well
   resources :recipes, only: [:index, :update, :destroy]
 
-  # allow PUT / DELETE meal_plans
-  resources :meal_plans, only: [:update, :destroy]
-
   # specify exact form of GET /recipes/:id to avoid conflict with /search 
   # :id can only contain digits
-  get '/:id', to: 'recipes#show', constraints: { id: /\d.+/ }
+  get 'recipes/:id', to: 'recipes#show', constraints: { id: /\d.+/ }
+
+  # allow PUT / DELETE meal_plans
+  resources :meal_plans, only: [:show, :update, :destroy]
 
   # add recipes/search route
   resources :recipes do 
     collection do
       get 'search'
-    end 
+    end  
   end 
 
 end

--- a/db/migrate/20180520200239_create_meal_plan_recipes.rb
+++ b/db/migrate/20180520200239_create_meal_plan_recipes.rb
@@ -1,0 +1,15 @@
+class MealPlanRecipes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :meal_plan_recipes do |t|
+      t.references :recipe, foreign_key: true
+      t.references :meal_plan, foreign_key: true
+      t.integer :meal, default: 1
+      t.integer :day, default: 1
+      t.timestamps
+    end
+
+    add_index :meal_plan_recipes, [:recipe_id, :meal_plan_id, :meal, :day], \
+               unique: true, :name => 'meal_plan_recipes_index'
+
+  end
+end

--- a/db/migrate/20180520200239_create_meal_plan_recipes.rb
+++ b/db/migrate/20180520200239_create_meal_plan_recipes.rb
@@ -1,4 +1,4 @@
-class MealPlanRecipes < ActiveRecord::Migration[5.1]
+class CreateMealPlanRecipes < ActiveRecord::Migration[5.1]
   def change
     create_table :meal_plan_recipes do |t|
       t.references :recipe, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180511045535) do
+ActiveRecord::Schema.define(version: 20180520200239) do
 
   create_table "dietary_restriction_recipes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "dietary_restriction_id"
@@ -51,6 +51,18 @@ ActiveRecord::Schema.define(version: 20180511045535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["ingredient_category_id"], name: "index_ingredients_on_ingredient_category_id"
+  end
+
+  create_table "meal_plan_recipes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "recipe_id"
+    t.bigint "meal_plan_id"
+    t.integer "meal", default: 1
+    t.integer "day", default: 1
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["meal_plan_id"], name: "index_meal_plan_recipes_on_meal_plan_id"
+    t.index ["recipe_id", "meal_plan_id", "meal", "day"], name: "meal_plan_recipes_index", unique: true
+    t.index ["recipe_id"], name: "index_meal_plan_recipes_on_recipe_id"
   end
 
   create_table "meal_plans", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -125,6 +137,8 @@ ActiveRecord::Schema.define(version: 20180511045535) do
   add_foreign_key "ingredient_recipes", "measures"
   add_foreign_key "ingredient_recipes", "recipes"
   add_foreign_key "ingredients", "ingredient_categories"
+  add_foreign_key "meal_plan_recipes", "meal_plans"
+  add_foreign_key "meal_plan_recipes", "recipes"
   add_foreign_key "meal_plans", "users"
   add_foreign_key "recipes", "users"
   add_foreign_key "shopping_lists", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,13 +21,13 @@ ActiveRecord::Schema.define(version: 20180520200239) do
   end
 
   create_table "dietary_restrictions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "ingredient_categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 20180520200239) do
   end
 
   create_table "ingredients", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.bigint "ingredient_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 20180520200239) do
   end
 
   create_table "measures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -118,17 +118,16 @@ ActiveRecord::Schema.define(version: 20180520200239) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.string "nickname"
-    t.string "first_name"
-    t.string "last_name"
+    t.string "nickname", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
     t.string "image"
-    t.string "email"
+    t.string "email", null: false
     t.integer "default_servings"
     t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end

--- a/spec/controllers/meal_plans_controller_spec.rb
+++ b/spec/controllers/meal_plans_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MealPlansController, type: :controller do
+
+end

--- a/spec/factories/meal_plan_recipes.rb
+++ b/spec/factories/meal_plan_recipes.rb
@@ -1,0 +1,12 @@
+# meal_plan_recipe spec
+# spec/factories/meal_plan_recipe.rb
+
+FactoryBot.define do
+    factory :meal_plan_recipe do
+      recipe_id nil
+      meal_plan_id nil
+      meal { Faker::Number.between(0,3) }
+      day { Faker::Number.between(0,6) }
+    end
+  end 
+  

--- a/spec/factories/meal_plan_recipes.rb
+++ b/spec/factories/meal_plan_recipes.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     factory :meal_plan_recipe do
       recipe_id nil
       meal_plan_id nil
-      meal { Faker::Number.between(0,3) }
-      day { Faker::Number.between(0,6) }
+      meal { MealPlanRecipe.meals.values.sample }
+      day { MealPlanRecipe.days.values.sample }
     end
   end 
   

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -1,24 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe MealPlanRecipe, type: :model do
-
-  # must have an amount
-  it { is_expected.to validate_presence_of :day }
-  it { is_expected.to validate_presence_of :meal }
-
-  # must map to a recipe 
-  it { is_expected.to belong_to :recipe }
-
-   #must map to a meal plan 
-  it { is_expected.to belong_to :meal_plan }
-
-  describe 'uniqueness validations' do 
-    let!(:test_user) { create(:user) }
-    let!(:test_recipe) { create(:recipe, user: test_user) }
-    let!(:test_meal_plan) { create(:meal_plan, user: test_user) }
-
-    subject { MealPlanRecipe.new( recipe: test_recipe, meal_plan: test_meal_plan ) }
-    it { is_expected.to validate_uniqueness_of(:meal_plan_id).scoped_to(:recipe_id, :day, :meal) }
-  end 
-
+  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe MealPlanRecipe, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+    
+  # must have an amount
+    it { is_expected.to validate_presence_of :day }
+    it { is_expected.to validate_presence_of :meal }
+
+    # must map to an meal_plan 
+    it { is_expected.to belong_to :meal_plan }
+  
+    # must map to a recipe 
+    it { is_expected.to belong_to :recipe }
+  
+    describe 'uniqueness validations' do 
+      let!(:test_user) { create(:user) }
+      let!(:test_recipe) { create(:recipe, user: test_user) }
+      let!(:test_meal_plan) { create(:meal_plan, user: test_user) }
+  
+      subject { create(:meal_plan_recipe, recipe_id: test_recipe.id, meal_plan_id: test_meal_plan.id ) }
+   
+      it { is_expected.to validate_uniqueness_of(:meal_plan_id).scoped_to(:recipe_id, :day, :meal) }
+    end
+
+
+
 end

--- a/spec/models/meal_plan_recipe_spec.rb
+++ b/spec/models/meal_plan_recipe_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe MealPlanRecipe, type: :model do
+
+  # must have an amount
+  it { is_expected.to validate_presence_of :day }
+  it { is_expected.to validate_presence_of :meal }
+
+  # must map to a recipe 
+  it { is_expected.to belong_to :recipe }
+
+   #must map to a meal plan 
+  it { is_expected.to belong_to :meal_plan }
+
+  describe 'uniqueness validations' do 
+    let!(:test_user) { create(:user) }
+    let!(:test_recipe) { create(:recipe, user: test_user) }
+    let!(:test_meal_plan) { create(:meal_plan, user: test_user) }
+
+    subject { MealPlanRecipe.new( recipe: test_recipe, meal_plan: test_meal_plan ) }
+    it { is_expected.to validate_uniqueness_of(:meal_plan_id).scoped_to(:recipe_id, :day, :meal) }
+  end 
+
+end

--- a/spec/models/meal_plan_spec.rb
+++ b/spec/models/meal_plan_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe MealPlan, type: :model do
 
   # name must exist, must be unique
   it { is_expected.to validate_presence_of :name }
+
+  # describe m:n relationship between meal plans and recipes
+  it { is_expected.to have_many(:meal_plan_recipes).dependent(:destroy) }
+  it { is_expected.to have_many(:recipes).through(:meal_plan_recipes) }
   
   describe 'uniqueness validations' do
     let!(:test_user) { create(:user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  # association tests
 
   it { is_expected.to have_many :recipes }
   # validation tests
@@ -11,8 +10,10 @@ RSpec.describe User, type: :model do
   it { is_expected.to validate_presence_of :encrypted_password }
   it { is_expected.to validate_presence_of :default_servings }
 
+  # association tests
   it { is_expected.to have_many(:recipes).dependent(:destroy) }
-
+  it { is_expected.to have_many(:meal_plans).dependent(:destroy) }
+  
   describe 'uniqueness validations' do 
     subject { create(:user) }
     it { is_expected.to validate_uniqueness_of :nickname }

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'MealPlans API', type: :request do
       it 'returns status code unauthorized' do
         expect(response).to have_http_status(401)
       end 
-    end
+    end # end context
 
   end # end describe
 

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe 'MealPlans API', type: :request do
         expect(response).to have_http_status 400
       end
     end
+
+    context 'when user is not authorized to POST' do
+      before { auth_post user_1, "/users/#{user_2.id}/meal_plans", params: {} }
+
+      it 'returns unauthorized' do
+        expect(response).to have_http_status 401
+      end
+    end 
  
   end # end describe block
 

--- a/spec/requests/meal_plans_spec.rb
+++ b/spec/requests/meal_plans_spec.rb
@@ -1,0 +1,248 @@
+# meal plans request spec
+# /spec/requests/meal_plans_spec.rb
+# test methods adapted from https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one
+
+require 'rails_helper'
+require 'support/request_spec_helper'
+require 'json'
+
+RSpec.describe 'MealPlans API', type: :request do
+
+  let(:num_recipes) { 3 }
+  let(:num_ingredients) { 1 }
+  let(:num_restrictions) { 1 }
+
+  let!(:user_1) { create(:user) } 
+  subject { auth_post user_1, '/auth', params: {  email: user_1.email,
+                                                  password: user_1.password,
+                                                  password_confirmation: user_1.password, 
+                                                  confirm_success_url: "www.google.com" } }
+
+  let!(:user_2) { create(:user) }
+
+  let!(:uid_1) { user_1.id }
+  let!(:uid_2) { user_2.id }
+
+  let!(:user_1_recipes) { create_recipe_list(user_1, num_recipes, num_ingredients, num_restrictions ) }
+  let!(:user_1_meal_plan) { create_meal_plan(user_1, user_1_recipes) }
+  
+  let(:first_recipe_id) { user_1_recipes.first.id }
+
+  #
+  # spec for GET /users/:id/recipes
+  #
+
+  describe "GET /users/:id/meal_plans" do
+    before { auth_get user_1, "/users/#{user_1.id}/meal_plans", params: {} }
+
+    context 'when meal plans area in database' do
+    
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns all of that user\'s meal plans' do
+        expect(json.size).to eq user_1_meal_plan.size      
+      end
+
+      it 'returns all recipes in each meal_plan' do
+        json.each do |mp|
+          meal_plan_recipes = mp['meal_plan_recipes']
+          expect(meal_plan_recipes.size).to eq num_recipes
+        end
+      end
+=begin
+      it 'returns appropriate day' do
+        json.each do |mp|
+      #    rest = rec['dietary_restriction_recipes']
+      #    expect(rest.size).to eq num_restrictions
+        end
+      end
+=end
+    end # end context
+
+  end # end describe
+
+  #
+  # spec for GET /recipes
+  #
+
+=begin
+  describe "GET /recipes" do
+    before { get "/recipes" } 
+
+    context 'when recipes are in database' do
+  
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns all recipes' do
+        expect(json.size).to eq user_1_recipes.size + user_2_recipes.size
+      end
+
+    end
+
+  end
+  
+  #
+  # spec for GET /recipes/:id
+  #
+
+  describe "GET /recipes/:id" do
+
+    before { get "/recipes/#{id}" }
+
+    context 'when recipe exists' do
+
+      # assuming a recipe exists with id == 1
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+      
+      it 'returns the recipe' do
+        expect(json['id']).to eq id
+      end
+
+    end
+
+    context 'when recipe record does not exist' do
+ 
+      let(:id) { -1 }
+     
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns not found message' do
+        expect(response.body).to match /Couldn't find Recipe/
+      end  
+
+    end # end context
+      
+  end # end describe block
+
+  #
+  # spec for POST /users/:id/recipes
+  #
+
+  describe 'POST /users/:id/recipes' do
+  
+    # creating some test data...building known good data 
+
+    let!(:ingredient_category) { create(:ingredient_category) }
+    let!(:ingredient) { create(:ingredient, ingredient_category_id: ingredient_category.id) }
+    let(:iid) { ingredient.id }
+
+    let!(:measure) { create(:measure) }
+    let!(:mid) { measure.id }
+
+    # use that data to build our recipe request
+
+    let(:valid_attrs) { { :recipe => {
+                           title: 'myrecipe', summary: 'it\'s a new one', 
+                           instructions: 'do a thing', 
+                           ingredient_recipes_attributes: [
+                                { ingredient_id: "#{iid}", measure_id: "#{mid}", amount: '3' } ] 
+                           } 
+                        } 
+                      }
+     
+    context 'when request attributes are valid' do
+      before { auth_post user_1, "/users/#{user_1.id}/recipes", params: valid_attrs }
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status 201
+      end
+    end
+
+    context 'when request attributes are invalid' do
+      before { auth_post user_1, "/users/#{user_1.id}/recipes", params: {} }
+
+      it 'returns status code 400' do
+        expect(response).to have_http_status 400
+      end
+
+    end
+ 
+  end # end describe block
+
+  #
+  # spec for PUT /recipes
+  #
+
+  describe "PUT /recipes" do
+
+    let(:valid_attrs) { { recipe: { title: 'croque monsieur' } } }
+    before { auth_put user_1, "/recipes/#{id}", params: valid_attrs }
+
+    context 'when recipe exists' do
+      it 'returns status code 204' do
+        expect(response).to have_http_status 204
+      end
+
+      it 'updates the recipe' do
+        updated_recipe = Recipe.find(id)
+        expect(updated_recipe.title).to match /croque monsieur/
+      end
+    end # end context
+
+    context 'when recipe does not exist' do
+
+      let(:id) { -1 }
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns a not found message' do
+        expect(response.body).to match /Couldn't find Recipe/
+      end
+
+    end # end context
+
+    context 'when user not authroized to PUT' do
+      before { auth_put user_1, "/recipes/#{user_2.recipes.first.id}", params: valid_attrs }
+      let!(:prevname) { user_2.recipes.first.title }
+
+      it 'returns unauthorized' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'has not modified the name' do
+        expect(user_2.recipes.first.title).to eq prevname
+      end
+
+    end # end ontext 
+
+  end # end describe block
+
+  #
+  # spec for DELETE /recipes
+  #
+
+  describe 'DELETE /recipes/:id' do
+
+    context 'when authorized user attempts to delete' do
+
+      before { auth_delete user_1, "/recipes/#{user_1.recipes.first.id}", params: {} }
+  
+      it 'returns status code 204' do
+        expect(response).to have_http_status 204
+      end
+
+    end
+
+    context 'when unauthorized user attempts to delete' do
+      
+      before { auth_delete user_1, "/recipes/#{user_2.recipes.first.id}", params: {} }
+
+      it 'returns unauthorized' do
+        expect(response).to have_http_status 401
+      end 
+
+    end
+
+  end # end describe block
+=end
+
+end # end test

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'Recipes API', type: :request do
   let!(:user_1_recipes) { create_recipe_list(user_1, num_recipes, num_ingredients, num_restrictions ) }
   let!(:user_2_recipes) { create_recipe_list(user_2, num_recipes, num_ingredients, 0 ) }
 
+  let(:user_2_first_title) { user_2_recipes.first.title }
+
   let(:id) { user_1_recipes.first.id }
 
   #
@@ -202,7 +204,7 @@ RSpec.describe 'Recipes API', type: :request do
 
     context 'when user not authroized to PUT' do
       before { auth_put user_1, "/recipes/#{user_2.recipes.first.id}", params: valid_attrs }
-      let!(:prevname) { user_2.recipes.first.title }
+      let!(:prevname) { user_2_first_title }
 
       it 'returns unauthorized' do
         expect(response).to have_http_status 401

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -164,8 +164,15 @@ RSpec.describe 'Recipes API', type: :request do
       it 'returns status code 400' do
         expect(response).to have_http_status 400
       end
-
     end
+
+    context 'when user is not authorized to POST' do
+      before { auth_post user_1, "/users/#{user_2.id}/recipes", params: {} }
+
+      it 'returns unauthorized' do
+        expect(response).to have_http_status 401
+      end
+    end 
  
   end # end describe block
 
@@ -202,7 +209,7 @@ RSpec.describe 'Recipes API', type: :request do
 
     end # end context
 
-    context 'when user not authroized to PUT' do
+    context 'when user not authorized to PUT' do
       before { auth_put user_1, "/recipes/#{user_2.recipes.first.id}", params: valid_attrs }
       let!(:prevname) { user_2_first_title }
 

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Recipes API', type: :request do
 
   let(:user_2_first_title) { user_2_recipes.first.title }
 
-  let(:id) { user_1_recipes.first.id }
+  let(:user_1_first_rec_id) { user_1_recipes.first.id }
 
   #
   # spec for GET /users/:id/recipes
@@ -93,7 +93,7 @@ RSpec.describe 'Recipes API', type: :request do
 
   describe "GET /recipes/:id" do
 
-    before { get "/recipes/#{id}" }
+    before { get "/recipes/#{user_1_first_rec_id}" }
 
     context 'when recipe exists' do
 
@@ -103,14 +103,14 @@ RSpec.describe 'Recipes API', type: :request do
       end
       
       it 'returns the recipe' do
-        expect(json['id']).to eq id
+        expect(json['id']).to eq user_1_first_rec_id
       end
 
     end
 
     context 'when recipe record does not exist' do
  
-      let(:id) { -1 }
+      let(:user_1_first_rec_id) { -1 }
      
       it 'returns status code 404' do
         expect(response).to have_http_status 404
@@ -176,7 +176,7 @@ RSpec.describe 'Recipes API', type: :request do
   describe "PUT /recipes" do
 
     let(:valid_attrs) { { recipe: { title: 'croque monsieur' } } }
-    before { auth_put user_1, "/recipes/#{id}", params: valid_attrs }
+    before { auth_put user_1, "/recipes/#{user_1_first_rec_id}", params: valid_attrs }
 
     context 'when recipe exists' do
       it 'returns status code 204' do
@@ -184,14 +184,14 @@ RSpec.describe 'Recipes API', type: :request do
       end
 
       it 'updates the recipe' do
-        updated_recipe = Recipe.find(id)
+        updated_recipe = Recipe.find(user_1_first_rec_id)
         expect(updated_recipe.title).to match /croque monsieur/
       end
     end # end context
 
     context 'when recipe does not exist' do
 
-      let(:id) { -1 }
+      let(:user_1_first_rec_id) { -1 }
       it 'returns status code 404' do
         expect(response).to have_http_status 404
       end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -44,4 +44,20 @@ module RequestSpecHelper
 
   end
 
+  #
+  # create a meal plan + assign recipes, given a user and a list of recipes
+  #
+
+  def create_meal_plan(user, recipes) 
+
+    # create a recipe with random ingredients, restrictions
+    meal_plan = create(:meal_plan, user_id: user.id)
+    recipes.each do |rec|
+      create(:meal_plan_recipe, recipe_id: rec.id, meal_plan_id: meal_plan.id)
+    end 
+
+    return meal_plan
+
+  end 
+
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -60,4 +60,16 @@ module RequestSpecHelper
 
   end 
 
+  def create_meal_plan_list(user, num_meal_plans, recipes_per_meal_plan) 
+
+    meal_plan_list = Array.new
+    num_meal_plans.times do
+      recipes = create_list(:recipe, recipes_per_meal_plan, user_id: user.id)
+      meal_plan_list << create_meal_plan(user, recipes)
+    end 
+
+    return meal_plan_list
+
+  end 
+
 end


### PR DESCRIPTION
## Meal Plans

- Added support for Meal Plans. 
- Includes request specs + model specs, controllers, models, serializers, and factories. 

New API routes:
```
GET /users/:id/meal_plans
GET /meal_plans/:id
POST users/:id/meal_plans/
PUT /meal_plans/:id
DELETE /meal_plans/:id
```
Note that all routes require authorization + `current_user` to match user. 

## Recipes

- Improved unit tests + controllers, enforcing authorization + `current_user == user` for POST route.
- Cleaned up unit tests for consistency with MealPlans tests.