### PR TITLE
Adding code coverage metrics via Simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 !/tmp/.keep
 
 .byebug_history
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
 end
 
 group :test do
+  gem 'simplecov', require: false
   gem 'factory_bot_rails', '~> 4.0'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       devise (> 3.5.2, < 4.5)
       rails (< 6)
     diff-lcs (1.3)
+    docile (1.3.0)
     erubi (1.7.1)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -76,6 +77,7 @@ GEM
     hashie (3.5.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    json (2.1.0)
     jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -153,6 +155,11 @@ GEM
     ruby_dep (1.5.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -200,6 +207,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   ruby_dep
   shoulda-matchers (~> 3.1)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.1)
   tzinfo-data

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,11 @@
 # the additional setup, and require it from the spec files that actually need
 # it.
 #
+
+# add simplecov for code coverage metrics
+require 'simplecov'
+SimpleCov.start
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Adding SimpleCov gem, which automatically collects code coverage results on each execution of Rspec.

After running `bundle exec rspec`, you can find coverage results in `/coverage/index.html`