### PR TITLE
Adding servings to recipes table, updating controllers + models + specs

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -116,7 +116,7 @@ class RecipesController < ApplicationController
 
     # define acceptable params for post, patch
     def recipe_params
-      params.require(:recipe).permit(:title, :summary, :instructions, 
+      params.require(:recipe).permit(:title, :summary, :instructions, :servings,
                                      dietary_restriction_recipes_attributes: [:id, :dietary_restriction_id], 
                                      ingredient_recipes_attributes: [:id, :ingredient_id, :measure_id, :amount, :_destroy] )
     end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -6,6 +6,9 @@ class Recipe < ApplicationRecord
   # but do not destroy ingredients themselves
   has_many :ingredient_recipes, dependent: :destroy
   has_many :ingredients, :through => :ingredient_recipes
+
+  # validates that servings count is between 1 and 32
+  validates :servings, :inclusion => { :in => 1..32 }
   
   # allow Recipe model to create ingredient_recipes
   accepts_nested_attributes_for :ingredient_recipes, allow_destroy: true

--- a/app/serializers/recipe_serializer.rb
+++ b/app/serializers/recipe_serializer.rb
@@ -2,7 +2,7 @@
 # Recipe serializer
 
 class RecipeSerializer < ActiveModel::Serializer
-  attributes :id, :title, :summary, :instructions
+  attributes :id, :title, :summary, :instructions, :servings
   has_many :ingredient_recipes
   has_many :dietary_restriction_recipes
   has_one :user, :serializer => AbbrevUserSerializer

--- a/db/migrate/20180531012854_add_servings_to_recipe.rb
+++ b/db/migrate/20180531012854_add_servings_to_recipe.rb
@@ -1,0 +1,18 @@
+class AddServingsToRecipe < ActiveRecord::Migration[5.1]
+  
+  # guard model stub
+  class MigrationRecipe < ActiveRecord::Base
+    self.table_name = :recipes
+  end
+  
+  def change
+    add_column(:recipes, :servings, :integer, :null => false)
+
+    MigrationRecipe.reset_column_information
+    MigrationRecipe.find_each do |recipe|
+      recipe.servings = 1
+      recipe.save!
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180527202228) do
+ActiveRecord::Schema.define(version: 20180531012854) do
 
   create_table "dietary_restriction_recipes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "dietary_restriction_id"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 20180527202228) do
     t.text "instructions", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "servings", null: false
     t.index ["title", "user_id"], name: "index_recipes_on_title_and_user_id", unique: true
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,10 +35,29 @@ salted_peanuts = Ingredient.create!(name: 'salted peanuts', ingredient_category:
 cup = Measure.create!(name: 'cup')
 lb = Measure.create!(name: 'lb')
 
-fishsticks = Recipe.create!(title: 'fishsticks', summary: 'some good fishsticks', instructions: 'put them in the oven', user: user1)
-croque_monsieur = Recipe.create!(title: 'croque monsieur', summary: 'a cheesy sandwich the whole family can enjoy', instructions: 'order it at a restaurant', user: user2)
-candied_yams = Recipe.create!(title: 'candied yams', summary: 'a family treat, great with fishsticks', instructions: 'buy a yam, then candy it', user: user2)
-pizza = Recipe.create!(title: 'pizza', summary: 'my fave-rave food', instructions: 'ditch the fishsticks, then call 1-800-NO-FSHTK', user: user2)
+fishsticks = Recipe.create!(title: 'fishsticks', 
+                            summary: 'some good fishsticks', 
+                            instructions: 'put them in the oven', 
+                            user: user1, 
+                            servings: 1)
+
+croque_monsieur = Recipe.create!(title: 'croque monsieur', 
+                                 summary: 'a cheesy sandwich the whole family can enjoy', 
+                                 instructions: 'order it at a restaurant', 
+                                 user: user2, 
+                                 servings: 2)
+
+candied_yams = Recipe.create!(title: 'candied yams',
+                              summary: 'a family treat, great with fishsticks', 
+                              instructions: 'buy a yam, then candy it', 
+                              user: user2, 
+                              servings: 3)
+
+pizza = Recipe.create!(title: 'pizza', 
+                       summary: 'my fave-rave food', 
+                       instructions: 'ditch the fishsticks, then call 1-800-NO-FSHTK', 
+                       user: user2, 
+                       servings: 4)
 
 # fishsticks
 IngredientRecipe.create!(ingredient: salt, measure: cup, recipe: fishsticks, amount: 3.5)

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     summary { Faker::Lorem.sentence }
     source { Faker:: Internet.domain_name }
     instructions { Faker::Lorem.paragraph }
+    servings { Faker::Number.between(1,32) }
   end
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -6,16 +6,18 @@ RSpec.describe Recipe, type: :model do
   it { is_expected.to validate_presence_of :summary }
   it { is_expected.to validate_presence_of :instructions }
 
+  # range of servings is 1..32
+  it { is_expected.to validate_inclusion_of(:servings).in_array( (1..32).to_a ) }
+
   # association tests
   it { is_expected.to belong_to :user }
   it { is_expected.to have_many(:ingredient_recipes).dependent(:destroy) }
   it { is_expected.to have_many(:ingredients).through(:ingredient_recipes) }
-
   it { is_expected.to have_many(:dietary_restriction_recipes).dependent(:destroy) }
 
   describe 'uniqueness validations' do 
     let!(:test_user) { create(:user) }
-    subject { Recipe.new(user: test_user, title: 'Fishsticks', summary: 'Some good fishsticks', instructions: 'The best you\'ll find') }
+    subject { Recipe.new(user: test_user, title: 'Fishsticks', summary: 'Some good fishsticks', instructions: 'The best you\'ll find', servings: 1) }
     it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:title) }
   end
 

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe 'Recipes API', type: :request do
     let(:valid_attrs) { { :recipe => {
                            title: 'myrecipe', summary: 'it\'s a new one', 
                            instructions: 'do a thing', 
+                           servings: 1,
                            ingredient_recipes_attributes: [
                                 { ingredient_id: "#{iid}", measure_id: "#{mid}", amount: '3' } ] 
                            } 


### PR DESCRIPTION
Added a mandatory "servings" field to the Recipe model + database table, enforcing a range of integers in [1..32]. 

Updated controllers, specs, and migrations to match. 