### PR TITLE
Expanding recipe information returned from /meal_plans endpoints

### DIFF
--- a/app/serializers/abbrev_recipe_serializer.rb
+++ b/app/serializers/abbrev_recipe_serializer.rb
@@ -1,7 +1,0 @@
-# app/models/serializers/abbrev_recipe_serializer.rb
-# Abbreviated Recipe serializer
-
-class AbbrevRecipeSerializer < ActiveModel::Serializer
-  attributes :id, :title
-end
-  

--- a/app/serializers/meal_plan_recipe_serializer.rb
+++ b/app/serializers/meal_plan_recipe_serializer.rb
@@ -3,5 +3,5 @@
 
 class MealPlanRecipeSerializer < ActiveModel::Serializer
   attributes :id, :day, :meal
-  has_one :recipe, :serializer => AbbrevRecipeSerializer
+  has_one :recipe, :serializer => RecipeSerializer
 end


### PR DESCRIPTION
Expanding the Recipe data returned from calls to /meal_plans endpoints.

Now, full recipe information is returned (ID, title, summary, instructions, etc.), instead of abbreviated information (ID / title). This will help facilitate meal plan display / manipulation on the client.