### PR TITLE
Revising meal plan serializers

### DIFF
--- a/app/serializers/meal_plan_recipe_serializer.rb
+++ b/app/serializers/meal_plan_recipe_serializer.rb
@@ -2,7 +2,7 @@
 # MealPlanRecipe model serializer
 
 class MealPlanRecipeSerializer < ActiveModel::Serializer
-  attributes :id, :day, :meal
+  attributes :day, :meal
   has_one :recipe_id
   
   def recipe_id

--- a/app/serializers/meal_plan_recipe_serializer.rb
+++ b/app/serializers/meal_plan_recipe_serializer.rb
@@ -3,5 +3,10 @@
 
 class MealPlanRecipeSerializer < ActiveModel::Serializer
   attributes :id, :day, :meal
-  has_one :recipe, :serializer => RecipeSerializer
+  has_one :recipe_id
+  
+  def recipe_id
+    object.recipe.id
+  end
+  
 end


### PR DESCRIPTION
Revising Meal Plan serializer such that, for each meal, only the recipe_id is returned, not the full recipe description. This adds consistency between JSON formats for GET/POST requests, and makes front-end implementation simpler.