### PR TITLE
Adding measures endpoints to API

### DIFF
--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -1,0 +1,49 @@
+class MeasuresController < ApplicationController
+
+# Measures controller
+# /app/controllers/measures_controller.rb
+
+  before_action :set_measure, only: [:show, :update, :destroy]
+  
+  # GET /measures
+  def index
+    @measures = Measure.all
+    render json: @measures, status: :ok
+  end
+
+  # POST /measures
+  def create
+    @measure = Measure.create!(measure_params)
+    render json: @measure, status: :created
+  end
+
+  # GET /measures/:id
+  def show
+    render json: @measure, status: :ok
+  end
+
+  # PUT /measures/:id
+  def update 
+    @measure.update(measure_params)
+    head :no_content
+  end
+
+  # DELETE /measures/:id
+  def destroy 
+    @measure.destroy
+    head :no_content
+  end 
+
+  private
+  
+    # set @measure for GET, UPDATE, DELETE
+    def set_measure
+      @measure = Measure.find(params[:id])
+    end
+  
+    # whitelist fields
+    def measure_params
+      params.permit(:id, :name)
+    end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
 
-  #devise_for :users
   api_version(:module => "V1", :path => {:value => "v1"}) do
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
@@ -19,6 +18,9 @@ Rails.application.routes.draw do
 
   # set up dietary_restrictions routes
   resources :dietary_restrictions
+
+  # set up dietary_restrictions routes
+  resources :measures
 
   # set up users + recipes, meal_plans
   # (1 user : m recipes)

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MeasuresController, type: :controller do
+
+end

--- a/spec/requests/measures_spec.rb
+++ b/spec/requests/measures_spec.rb
@@ -1,0 +1,133 @@
+# measures request spec
+# /spec/request/measures.rb
+# test methods adapted from: https://scotch.io/tutorials/build-a-restful-json-api-with-rails-5-part-one
+
+require 'rails_helper'
+
+RSpec.describe 'Measures API', type: :request do
+  let!(:measures) { create_list(:measure, 10) }
+  let(:measure_id) { measures.first.id }
+
+  # spec for GET/measures
+  describe 'GET /measures' do
+
+    before { get '/measures' }
+
+    it 'returns measures' do
+      expect(json).not_to be_empty
+      expect(json.size).to eq 10
+    end
+
+    it 'returns status 200' do  
+      expect(response).to have_http_status 200
+    end
+ 
+  end 
+
+  # spec for GET /measures/:id
+  describe 'GET /measures/:id' do
+ 
+    before { get "/measures/#{measure_id}" }
+
+    # expect a request for category id of :measure_id
+    context 'when the record exists' do
+      it 'returns the restriction' do
+        expect(json).not_to be_empty
+        expect(json['id']).to eq measure_id
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status 200
+      end
+    end
+  
+    context 'when the record does not exist' do
+      let(:measure_id) { -1 }
+
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns not found message' do
+        expect(response.body).to match /Couldn't find Measure/
+      end
+    end    
+ 
+  end
+
+  # spec for POST /measures
+  describe 'POST /measures' do
+  
+    let(:valid_attributes) { {name: 'Teaspoons'} }
+
+    context 'when request is valid' do
+      before { post '/measures', params: valid_attributes}
+
+      it 'creates a masure' do
+        expect( json['name'] ).to eq 'Teaspoons'
+      end
+
+      it 'returns status code 201' do
+        expect(response).to have_http_status 201
+      end
+    end
+
+    context 'when request is invalid' do
+      before { post '/measures', params: { } }
+
+      it 'returns status code 422' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'returns validation failure message' do
+        expect(response.body).to match /Validation failed: Name can't be blank/
+      end
+    end
+ 
+  end
+
+  # spec for PUT /measures/:id
+  describe 'PUT /measures/:id' do
+
+    let(:valid_attributes) { {name: 'Teaspoons'} } 
+
+    context 'when record exists' do
+      before { put "/measures/#{measure_id}", params: valid_attributes}
+
+      it 'updates the record' do
+        expect(response.body).to be_empty
+      end
+
+      it 'returns status code 204' do
+        expect(response).to have_http_status 204
+      end
+    end
+    
+    context 'when record does not exist' do
+      let(:restriction_id) { 0 }
+      before { put "/measures/#{restriction_id}", params: valid_attributes}
+      
+      it 'returns status code 404' do
+        expect(response).to have_http_status 404
+      end
+
+      it 'returns a not found message' do
+        expect(response.body).to match /Couldn't find Measure/
+      end
+    end
+
+  end
+
+  # spec for DELETE /measures/:id
+  describe 'DELETE /measures/:id' do
+
+    before { delete "/measures/#{measure_id}" }
+
+    it 'returns status code 204' do
+      expect(response).to have_http_status 204 
+    end
+  
+  end
+
+end
+  


### PR DESCRIPTION
## Measures Endpoints

Adding the following endpoints to the API:

```
GET /measures
GET /measures/:id
POST /measures
PUT /measures/:id
DELETE /measures/:id
```

As with other "unauthenticated" routes, we'll eventually need to lock down the POST, PUT, and DELETE routes via an Admin interface, but this is suitable for MVP / demonstration purposes.